### PR TITLE
Small fixes in readme and target need only linking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ The path to the nvcc compiler will be automatically taken from the machine. In t
 source /cvmfs/sw.hsf.org/key4hep/setup.sh
 
 # get nvcc 11.4, if needed
-source /cvmfs/sft.cern.ch/lcg/releases/cuda/11.4-166ec/x86_64-centos7-gcc11-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/contrib/cuda/11.4/x86_64-centos8/setup.sh
 
 # then setup this project
 git clone --recurse-submodules https://github.com/key4hep/k4Clue.git

--- a/src/k4clue/CMakeLists.txt
+++ b/src/k4clue/CMakeLists.txt
@@ -17,8 +17,6 @@ gaudi_add_module(ClueGaudiAlgorithmWrapper
 )
 
 target_include_directories(ClueGaudiAlgorithmWrapper PUBLIC
-  k4FWCore::k4FWCore
-  EDM4HEP::edm4hep
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Set correct source for nvcc
- cmake: targets need only be linked

ENDRELEASENOTES
