### PR TITLE
ci: use nightlies to fix cuda build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ compile_and_test:
           - merge_requests
           - schedules
     script:
-        - source /cvmfs/sw.hsf.org/key4hep/setup.sh
+        - source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh
         - source /cvmfs/sft.cern.ch/lcg/contrib/cuda/11.4/x86_64-centos8/setup.sh
         - git submodule init; git submodule update
         - mkdir build; cd build


### PR DESCRIPTION
k4CLUE needs the workaround in https://github.com/AIDASoft/podio/pull/333 that is currently only in master. Once this change is released the release stack can be added as well.
