### PR TITLE
Move DD4hep up in CMakeLists, remove Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,31 +38,14 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
-find_package(Boost REQUIRED)
-if(Boost_FOUND)
-  message(STATUS "Boost package found!")
-endif()
-
+find_package(DD4hep REQUIRED)
 find_package(EDM4HEP)
 if(EDM4HEP_FOUND)
   message(STATUS "EDM4HEP package found!")
 endif()
-find_package(DD4hep)
-if(DD4HEP_FOUND)
-  message(STATUS "DD4HEP package found!")
-endif()
 
 find_package(k4FWCore REQUIRED)
-if(k4FWCore_FOUND)
-  message(STATUS "k4FWCore package found!")
-endif()
 find_package(Gaudi REQUIRED)
-if(Gaudi_FOUND)
-  message(STATUS "Gaudi package found!")
-endif()
-
-#gaudi_install(PYTHON)
-#gaudi_install(SCRIPTS)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,7 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
 endif()
 
 find_package(DD4hep REQUIRED)
-find_package(EDM4HEP)
-if(EDM4HEP_FOUND)
-  message(STATUS "EDM4HEP package found!")
-endif()
+find_package(EDM4HEP REQUIRED)
 
 find_package(k4FWCore REQUIRED)
 find_package(Gaudi REQUIRED)

--- a/src/k4clue/CMakeLists.txt
+++ b/src/k4clue/CMakeLists.txt
@@ -18,8 +18,6 @@ limitations under the License.
 ]]
 
 # CLUE as Gaudi algorithm
-find_package(k4FWCore)
-find_package(EDM4HEP)
 
 gaudi_add_module(ClueGaudiAlgorithmWrapper
   SOURCES


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DD4hep up in CMakeLists.txt, preventing cases where another package finds python and uses a different version from what DD4hep wants. This can happen when there are multiple versions available. If a package that is found before DD4hep finds a version of python that it likes (typically the newest one) but it isn't the one DD4hep wants (the one that has been used when compiling ROOT) then `find_package(DD4hep)` will fail.
- Remove Boost that is not used anywhere and status messages; if the packages are not found there will be a message saying that since they are required.

ENDRELEASENOTES