### PR TITLE
Transparently switch to optional parameter values

### DIFF
--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -21,6 +21,8 @@
 // podio specific includes
 #include "DDSegmentation/BitFieldCoder.h"
 
+#include "podio/podioVersion.h"
+
 using namespace dd4hep ;
 using namespace DDSegmentation ;
 
@@ -114,7 +116,11 @@ StatusCode CLUENtuplizer::execute() {
   cluster_coll = cluster_handle.get();
 
   // Get collection metadata cellID which is valid for both EB, EE and Clusters
-  const auto cellIDstr = cellIDHandle.get();
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
+  const auto cellIDstr = cellIDHandle.get().value();
+#else
+  const auto& cellIDstr = cellIDHandle.get();
+#endif
   const BitFieldCoder bf(cellIDstr);
   cleanTrees();
 

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -23,6 +23,8 @@
 // podio specific includes
 #include "DDSegmentation/BitFieldCoder.h"
 
+#include "podio/podioVersion.h"
+
 using namespace dd4hep ;
 using namespace DDSegmentation ;
 using namespace std;
@@ -342,7 +344,11 @@ StatusCode ClueGaudiAlgorithmWrapper::execute() {
   EE_calo_coll = EE_calo_handle.get();
 
   // Get collection metadata cellID which is valid for both EB and EE
-  const auto cellIDstr = cellIDHandle.get();
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
+  const auto cellIDstr = cellIDHandle.get().value();
+#else
+  const auto& cellIDstr = cellIDHandle.get();
+#endif
   const BitFieldCoder bf(cellIDstr);
 
   // Output CLUE clusters


### PR DESCRIPTION
BEGINRELEASENOTES

- Introduce pre-processor checks to transparently switch to the new `std::optional` return values of `podio::Frame::getParameter` (introduced with [AIDASoft/podio#580](https://github.com/AIDASoft/podio/pull/580))

ENDRELEASENOTES
