### PR TITLE
Fix warnings related to deprecated labels

### DIFF
--- a/include/CLUENtuplizer.h
+++ b/include/CLUENtuplizer.h
@@ -97,7 +97,7 @@ private:
   mutable DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle {"EndcapInputHits", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::EventHeaderCollection> ev_handle {"EventHeader", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::MCParticleCollection> mcp_handle {"MCParticles", Gaudi::DataHandle::Reader, this};
-  MetaDataHandle<std::string> cellIDHandle {EB_calo_handle, edm4hep::CellIDEncoding, Gaudi::DataHandle::Reader};
+  MetaDataHandle<std::string> cellIDHandle {EB_calo_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
 
   bool singleMCParticle = false;
 

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -75,7 +75,7 @@ public:
   // Handle to read the calo cells and their cellID 
   mutable DataHandle<edm4hep::CalorimeterHitCollection> EB_calo_handle {"BarrelInputHits", Gaudi::DataHandle::Reader, this};
   mutable DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle {"EndcapInputHits", Gaudi::DataHandle::Reader, this};
-  MetaDataHandle<std::string> cellIDHandle {EB_calo_handle, edm4hep::CellIDEncoding, Gaudi::DataHandle::Reader};
+  MetaDataHandle<std::string> cellIDHandle {EB_calo_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
 
   // CLUE Algo
   mutable CLICdetBarrelCLUEAlgo clueAlgoBarrel_;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix warnings related to deprecated labels (change `edm4hep::CellIDEncoding` to `edm4hep::labels::CellIDEncoding`.

ENDRELEASENOTES

Merging this to have a new tag