### PR TITLE
Enable the warnings coming from Key4hepConfig and fix them

### DIFF
--- a/include/CLUEAlgo.h
+++ b/include/CLUEAlgo.h
@@ -20,15 +20,12 @@
 #define CLUEAlgo_h
 
 // C/C++ headers
-#include <set>
 #include <string>
 #include <vector>
 #include <map>
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <functional>
-#include <chrono>
 
 #include "LayerTiles.h"
 #include "Points.h"
@@ -54,7 +51,6 @@ public:
       std::cout << "," << TILES::constants_type_t::nRows << " )" << std::endl;
     }
   }
-  ~CLUEAlgo_T(){} 
     
   // public variables
   float dc_, rhoc_, outlierDeltaFactor_;
@@ -138,8 +134,7 @@ public:
   std::string getVerboseString_(unsigned it,
 				float x, float y, int layer, float weight,
 				float rho, float delta,
-				int nh, int isseed, float clusterid,
-				unsigned nVerbose) const {
+				int nh, int isseed, float clusterid) const {
     std::stringstream s;
     std::string sep = ",";
     s << it << sep << x << sep << y << sep;
@@ -152,18 +147,18 @@ public:
     return s.str();
   }
   
-  void verboseResults(std::string outputFileName="cout", unsigned nVerbose=-1) const {
+  void verboseResults(std::string outputFileName="cout", int nVerbose=-1) const {
     if(verbose_)
       {
 	if (nVerbose==-1) nVerbose=points_.n;
     
 	std::string s;
 	s = "index,x,y,layer,weight,rho,delta,nh,isSeed,clusterId\n";
-	for(unsigned i=0; i<nVerbose; i++) {
+	for(int i=0; i<nVerbose; i++) {
 	  s += getVerboseString_(i, points_.x[i], points_.y[i], points_.layer[i],
 				 points_.weight[i], points_.rho[i], points_.delta[i],
 				 points_.nearestHigher[i], points_.isSeed[i],
-				 points_.clusterIndex[i], nVerbose);
+				 points_.clusterIndex[i]);
 	}
 
 	if(outputFileName.compare("cout")==0) //verbose to screen

--- a/include/CLUECalorimeterHit.h
+++ b/include/CLUECalorimeterHit.h
@@ -22,11 +22,9 @@
 #include "edm4hep/CalorimeterHit.h"
 #include <GaudiKernel/DataObject.h>
 
-using namespace edm4hep;
-
 namespace clue {
 
-class CLUECalorimeterHit : public CalorimeterHit, public DataObject {
+  class CLUECalorimeterHit : public edm4hep::CalorimeterHit, public DataObject {
 public:
   using CalorimeterHit::CalorimeterHit;
 
@@ -80,10 +78,10 @@ public:
   void setEta();
   void setPhi();
 
-  void setRho( float rho ) { m_rho = rho; };
-  void setDelta( float delta ) { m_delta = delta; };
-  void setStatus( Status status ) { m_status = status; };
-  void setClusterIndex( int clIdx ) { m_clusterIndex = clIdx; };
+  void setRho( float rho ) { m_rho = rho; }
+  void setDelta( float delta ) { m_delta = delta; }
+  void setStatus( Status status ) { m_status = status; }
+  void setClusterIndex( int clIdx ) { m_clusterIndex = clIdx; }
 
 private:
   std::uint8_t m_detectorRegion{0};

--- a/include/IO_helper.h
+++ b/include/IO_helper.h
@@ -31,9 +31,6 @@
 // podio specific includes
 #include "DDSegmentation/BitFieldCoder.h"
 
-using namespace dd4hep ;
-using namespace DDSegmentation ;
-
 void read_EDM4HEP_event(const edm4hep::CalorimeterHitCollection& calo_coll, std::string cellIDstr,
                         std::vector<float>& x, std::vector<float>& y, std::vector<int>& layer, std::vector<float>& weight) {
 
@@ -42,7 +39,7 @@ void read_EDM4HEP_event(const edm4hep::CalorimeterHitCollection& calo_coll, std:
   float phi_tmp;
 
   for (const auto& ch : calo_coll) {
-    const BitFieldCoder bf(cellIDstr);
+    const dd4hep::DDSegmentation::BitFieldCoder bf(cellIDstr);
     auto ch_layer = bf.get( ch.getCellID(), "layer");
     auto ch_energy = ch.getEnergy();
 

--- a/include/Points.h
+++ b/include/Points.h
@@ -38,7 +38,7 @@ struct Points {
   // std::vector<bool> behaves similarly to std::vector, but in order to be space efficient, it:
   // Does not necessarily store its elements as a contiguous array (so &v[0] + n != &v[n])
 
-  int n;
+  size_t n;
 
   void clear() {
     x.clear();

--- a/src/CLUECalorimeterHit.cpp
+++ b/src/CLUECalorimeterHit.cpp
@@ -30,8 +30,8 @@ CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch)
 
 CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalorimeterHit::DetectorRegion detRegion, const int layer)
   : CalorimeterHit(ch),
-    m_layer(layer),
-    m_detectorRegion(detRegion) {
+    m_detectorRegion(detRegion),
+    m_layer(layer) {
   setR();
   setEta();
   setPhi();
@@ -43,9 +43,9 @@ CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalor
     m_detectorRegion(detRegion),
     m_layer(layer),
     m_status(status),
-    m_clusterIndex(clusterIndex),
     m_rho(rho),
-    m_delta(delta) {
+    m_delta(delta),
+    m_clusterIndex(clusterIndex) {
   setR();
   setEta();
   setPhi();

--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -121,7 +121,7 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
   float totEnergy = 0;
   float totEnergyHits = 0;
   std::uint64_t totSize = 0;
-  bool foundInECAL = false;
+  // bool foundInECAL = false;
 
   info() << ClusterCollectionName << " : Total number of clusters =  " << int( cluster_coll->size() ) << endmsg;
   for (const auto& cl : *cluster_coll) {
@@ -137,7 +137,7 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
     // Printout the hits that are in Ecal but not included in the clusters
     int maxLayer = 0;
     for (const auto& hit : cl.getHits()) {
-      foundInECAL = false;
+      // foundInECAL = false;
 /*
       for (const auto& clEB : *EB_calo_coll) {
         if( clEB.getCellID() == hit.getCellID()){

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,6 @@ limitations under the License.
 # CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/include/modern/*.hpp")
 set(GLOB HEADER_LIST CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/include/*.h")
 
-set(CMAKE_CXX_FLAGS "-fPIC")
-
 ## Make an automatic library - will be static or dynamic based on user setting
 add_library(CLUEAlgo_lib CLUEAlgo.cc ${HEADER_LIST})
 

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -69,13 +69,13 @@ void ClueGaudiAlgorithmWrapper::exclude_stats_outliers(std::vector<float> &v) {
   float mean = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
   float sum_sq_diff = std::accumulate(
       v.begin(), v.end(), 0.0,
-      [mean](float acc, float x) { return acc + (x - mean) * (x - mean); });
+      [mean](float acc, float val) { return acc + (val - mean) * (val - mean); });
   float stddev = std::sqrt(sum_sq_diff / (v.size() - 1));
   std::cout << "Sigma cut outliers: " << stddev << std::endl;
   float z_score_threshold = 3.0;
   v.erase(std::remove_if(v.begin(), v.end(),
-                         [mean, stddev, z_score_threshold](float x) {
-            float z_score = std::abs(x - mean) / stddev;
+                         [mean, stddev, z_score_threshold](float val) {
+            float z_score = std::abs(val - mean) / stddev;
             return z_score > z_score_threshold;
           }),
           v.end());
@@ -83,8 +83,8 @@ void ClueGaudiAlgorithmWrapper::exclude_stats_outliers(std::vector<float> &v) {
 
 std::pair<float, float> ClueGaudiAlgorithmWrapper::stats(const std::vector<float> &v) {
   float m = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
-  float sum = std::accumulate(v.begin(), v.end(), 0.0, [m](float acc, float x) {
-    return acc + (x - m) * (x - m);
+  float sum = std::accumulate(v.begin(), v.end(), 0.0, [m](float acc, float val) {
+    return acc + (val - m) * (val - m);
   });
   auto den = v.size() > 1 ? (v.size() - 1) : v.size();
   return {m, std::sqrt(sum / den)};

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -177,7 +177,7 @@ std::map<int, std::vector<int> > ClueGaudiAlgorithmWrapper::runAlgo(std::vector<
   info() << "Finished running CLUE algorithm" << endmsg;
 
   // Including CLUE info in cluePoints
-  for(int i = 0; i < cluePoints.n; i++){
+  for(size_t i = 0; i < cluePoints.n; i++){
 
     clue_hits[i].setRho(cluePoints.rho[i]);
     clue_hits[i].setDelta(cluePoints.delta[i]);
@@ -285,9 +285,7 @@ void ClueGaudiAlgorithmWrapper::calculatePosition(edm4hep::MutableCluster* clust
   float z_log = 0.f;
   double thresholdW0_ = 2.9; //Min percentage of energy to contribute to the log-reweight position
 
-  float maxEnergyValue = 0.f;
-  unsigned int maxEnergyIndex = 0;
-  for (int i = 0; i < cluster->hits_size(); i++) {
+  for (size_t i = 0; i < cluster->hits_size(); i++) {
     float rhEnergy = cluster->getHits(i).getEnergy();
     float Wi = std::max(thresholdW0_ - std::log(rhEnergy / total_weight), 0.);
     x_log += cluster->getHits(i).getPosition().x * Wi;
@@ -417,6 +415,10 @@ StatusCode ClueGaudiAlgorithmWrapper::execute(const EventContext&) const {
   // Save CLUE calo hits
   auto pCHV = std::make_unique<clue::CLUECalorimeterHitCollection>(clue_hit_coll);
   const StatusCode scStatusV = eventSvc()->registerObject("/Event/CLUECalorimeterHitCollection", pCHV.release());
+  if (scStatusV.isFailure()) {
+    error() << "Failed to register CLUECalorimeterHitCollection" << endmsg;
+    return StatusCode::FAILURE;
+  }
   info() << "Saved " << clue_hit_coll.vect.size() << " CLUE calo hits in total. " << endmsg;
 
   // Save clusters as calo hits and add cellID to them


### PR DESCRIPTION
BEGINRELEASENOTES
- Enable the warnings coming from Key4hepConfig (that were being overwritten by setting `CMAKE_CXX_FLAGS` and fix them)

ENDRELEASENOTES