### PR TITLE
optimise cache usage and reduce class size

### DIFF
--- a/include/CLUECalorimeterHit.h
+++ b/include/CLUECalorimeterHit.h
@@ -42,7 +42,7 @@ public:
                      const float delta);
 
   /// Access the layer number
-  const std::uint64_t& getLayer() const;
+  uint32_t getLayer() const;
 
   /// Access the region of calorimeter
   bool inBarrel() const;
@@ -60,19 +60,22 @@ public:
   bool isSeed() const;
 
   /// Access the delta
-  const float& getDelta() const;
+  float getDelta() const;
 
   /// Access the rho
-  const float& getRho() const;
+  float getRho() const;
 
   /// Access the transverse position
-  const float& getR() const;
+  float getR() const;
 
   /// Access the eta
-  const float& getEta() const;
+  float getEta() const;
 
   /// Access the phi
-  const float& getPhi() const;
+  float getPhi() const;
+
+  /// Access cluster index
+  int32_t getClusterIndex() const;
 
   /// Set hit transverse global position, pseudorapidity and phi
   void setR();
@@ -82,18 +85,18 @@ public:
   void setRho(float rho) { m_rho = rho; }
   void setDelta(float delta) { m_delta = delta; }
   void setStatus(Status status) { m_status = status; }
-  void setClusterIndex(int clIdx) { m_clusterIndex = clIdx; }
+  void setClusterIndex(int32_t clIdx) { m_clusterIndex = clIdx; }
 
 private:
-  std::uint8_t m_detectorRegion{0};
-  std::uint64_t m_layer{};
-  std::uint8_t m_status{0};
-  float m_rho{};
-  float m_delta{};
-  float m_r{};
-  float m_eta{};
-  float m_phi{};
-  std::uint64_t m_clusterIndex{};
+  float m_eta;
+  float m_phi;
+  float m_r;
+  float m_rho;
+  float m_delta;
+  uint8_t m_detectorRegion;
+  uint8_t m_status;
+  uint32_t m_layer;
+  int32_t m_clusterIndex;
 };
 
 class CLUECalorimeterHitCollection : public DataObject {
@@ -102,5 +105,7 @@ public:
 };
 
 } // namespace clue
+
+std::ostream& operator<<(std::ostream& o, const clue::CLUECalorimeterHit& value);
 
 #endif

--- a/include/CLUENtuplizer.h
+++ b/include/CLUENtuplizer.h
@@ -73,6 +73,7 @@ private:
   mutable std::vector<int> m_hits_region;
   mutable std::vector<int> m_hits_layer;
   mutable std::vector<int> m_hits_status;
+  mutable std::vector<int> m_hits_clusId;
   mutable std::vector<float> m_hits_x;
   mutable std::vector<float> m_hits_y;
   mutable std::vector<float> m_hits_z;
@@ -100,6 +101,7 @@ private:
   mutable TTree* t_clhits{nullptr};
   mutable std::vector<int> m_clhits_event;
   mutable std::vector<int> m_clhits_layer;
+  mutable std::vector<int> m_clhits_id;
   mutable std::vector<float> m_clhits_x;
   mutable std::vector<float> m_clhits_y;
   mutable std::vector<float> m_clhits_z;

--- a/include/CLUENtuplizer.h
+++ b/include/CLUENtuplizer.h
@@ -39,42 +39,6 @@ class CLUENtuplizer : public Gaudi::Algorithm {
 public:
   /// Constructor.
   CLUENtuplizer(const std::string& name, ISvcLocator* svcLoc);
-  /// Destructor.
-  ~CLUENtuplizer() {
-    delete m_hits_event;
-    delete m_hits_region;
-    delete m_hits_layer;
-    delete m_hits_status;
-    delete m_hits_x;
-    delete m_hits_y;
-    delete m_hits_z;
-    delete m_hits_eta;
-    delete m_hits_phi;
-    delete m_hits_rho;
-    delete m_hits_delta;
-    delete m_hits_energy;
-    delete m_hits_MCEnergy;
-
-    delete m_clusters;
-    delete m_clusters_event;
-    delete m_clusters_maxLayer;
-    delete m_clusters_size;
-    delete m_clusters_totSize;
-    delete m_clusters_x;
-    delete m_clusters_y;
-    delete m_clusters_z;
-    delete m_clusters_energy;
-    delete m_clusters_totEnergy;
-    delete m_clusters_totEnergyHits;
-    delete m_clusters_MCEnergy;
-
-    delete m_clhits_event;
-    delete m_clhits_layer;
-    delete m_clhits_x;
-    delete m_clhits_y;
-    delete m_clhits_z;
-    delete m_clhits_energy;
-  };
   /// Initialize.
   virtual StatusCode initialize();
   /// Initialize tree.
@@ -105,41 +69,41 @@ private:
   SmartIF<ITHistSvc> m_ths; ///< THistogram service
 
   mutable TTree* t_hits{nullptr};
-  mutable std::vector<int>* m_hits_event = nullptr;
-  mutable std::vector<int>* m_hits_region = nullptr;
-  mutable std::vector<int>* m_hits_layer = nullptr;
-  mutable std::vector<int>* m_hits_status = nullptr;
-  mutable std::vector<float>* m_hits_x = nullptr;
-  mutable std::vector<float>* m_hits_y = nullptr;
-  mutable std::vector<float>* m_hits_z = nullptr;
-  mutable std::vector<float>* m_hits_eta = nullptr;
-  mutable std::vector<float>* m_hits_phi = nullptr;
-  mutable std::vector<float>* m_hits_rho = nullptr;
-  mutable std::vector<float>* m_hits_delta = nullptr;
-  mutable std::vector<float>* m_hits_energy = nullptr;
-  mutable std::vector<float>* m_hits_MCEnergy = nullptr;
+  mutable std::vector<int> m_hits_event;
+  mutable std::vector<int> m_hits_region;
+  mutable std::vector<int> m_hits_layer;
+  mutable std::vector<int> m_hits_status;
+  mutable std::vector<float> m_hits_x;
+  mutable std::vector<float> m_hits_y;
+  mutable std::vector<float> m_hits_z;
+  mutable std::vector<float> m_hits_eta;
+  mutable std::vector<float> m_hits_phi;
+  mutable std::vector<float> m_hits_rho;
+  mutable std::vector<float> m_hits_delta;
+  mutable std::vector<float> m_hits_energy;
+  mutable std::vector<float> m_hits_MCEnergy;
 
   mutable TTree* t_clusters{nullptr};
-  mutable std::vector<int>* m_clusters = nullptr;
-  mutable std::vector<int>* m_clusters_event = nullptr;
-  mutable std::vector<int>* m_clusters_maxLayer = nullptr;
-  mutable std::vector<int>* m_clusters_size = nullptr;
-  mutable std::vector<int>* m_clusters_totSize = nullptr;
-  mutable std::vector<float>* m_clusters_x = nullptr;
-  mutable std::vector<float>* m_clusters_y = nullptr;
-  mutable std::vector<float>* m_clusters_z = nullptr;
-  mutable std::vector<float>* m_clusters_energy = nullptr;
-  mutable std::vector<float>* m_clusters_totEnergy = nullptr;
-  mutable std::vector<float>* m_clusters_totEnergyHits = nullptr;
-  mutable std::vector<float>* m_clusters_MCEnergy = nullptr;
+  mutable std::vector<int> m_clusters;
+  mutable std::vector<int> m_clusters_event;
+  mutable std::vector<int> m_clusters_maxLayer;
+  mutable std::vector<int> m_clusters_size;
+  mutable std::vector<int> m_clusters_totSize;
+  mutable std::vector<float> m_clusters_x;
+  mutable std::vector<float> m_clusters_y;
+  mutable std::vector<float> m_clusters_z;
+  mutable std::vector<float> m_clusters_energy;
+  mutable std::vector<float> m_clusters_totEnergy;
+  mutable std::vector<float> m_clusters_totEnergyHits;
+  mutable std::vector<float> m_clusters_MCEnergy;
 
   mutable TTree* t_clhits{nullptr};
-  mutable std::vector<int>* m_clhits_event = nullptr;
-  mutable std::vector<int>* m_clhits_layer = nullptr;
-  mutable std::vector<float>* m_clhits_x = nullptr;
-  mutable std::vector<float>* m_clhits_y = nullptr;
-  mutable std::vector<float>* m_clhits_z = nullptr;
-  mutable std::vector<float>* m_clhits_energy = nullptr;
+  mutable std::vector<int> m_clhits_event;
+  mutable std::vector<int> m_clhits_layer;
+  mutable std::vector<float> m_clhits_x;
+  mutable std::vector<float> m_clhits_y;
+  mutable std::vector<float> m_clhits_z;
+  mutable std::vector<float> m_clhits_energy;
 
   mutable std::int32_t evNum;
 };

--- a/src/CLUECalorimeterHit.cpp
+++ b/src/CLUECalorimeterHit.cpp
@@ -38,24 +38,25 @@ CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalor
 CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalorimeterHit::DetectorRegion detRegion,
                                        const int layer, const CLUECalorimeterHit::Status status, const int clusterIndex,
                                        const float rho, const float delta)
-    : CalorimeterHit(ch), m_detectorRegion(detRegion), m_layer(layer), m_status(status), m_rho(rho), m_delta(delta),
+    : CalorimeterHit(ch), m_rho(rho), m_delta(delta), m_detectorRegion(detRegion), m_status(status), m_layer(layer),
       m_clusterIndex(clusterIndex) {
   setR();
   setEta();
   setPhi();
 }
 
-const std::uint64_t& CLUECalorimeterHit::getLayer() const { return m_layer; }
+uint32_t CLUECalorimeterHit::getLayer() const { return m_layer; }
 bool CLUECalorimeterHit::inBarrel() const { return (m_detectorRegion == barrel ? true : false); }
 bool CLUECalorimeterHit::inEndcap() const { return (m_detectorRegion == endcap ? true : false); }
 bool CLUECalorimeterHit::isFollower() const { return (m_status == follower ? true : false); }
 bool CLUECalorimeterHit::isSeed() const { return (m_status == seed ? true : false); }
 bool CLUECalorimeterHit::isOutlier() const { return (m_status == outlier ? true : false); }
-const float& CLUECalorimeterHit::getRho() const { return m_rho; }
-const float& CLUECalorimeterHit::getDelta() const { return m_delta; }
-const float& CLUECalorimeterHit::getR() const { return m_r; }
-const float& CLUECalorimeterHit::getEta() const { return m_eta; }
-const float& CLUECalorimeterHit::getPhi() const { return m_phi; }
+float CLUECalorimeterHit::getRho() const { return m_rho; }
+float CLUECalorimeterHit::getDelta() const { return m_delta; }
+float CLUECalorimeterHit::getR() const { return m_r; }
+float CLUECalorimeterHit::getEta() const { return m_eta; }
+float CLUECalorimeterHit::getPhi() const { return m_phi; }
+int32_t CLUECalorimeterHit::getClusterIndex() const { return m_clusterIndex; };
 
 void CLUECalorimeterHit::setEta() { m_eta = -1. * log(tan(atan2(m_r, getPosition().z) / 2.)); }
 
@@ -66,3 +67,20 @@ void CLUECalorimeterHit::setR() {
 }
 
 } // namespace clue
+
+std::ostream& operator<<(std::ostream& o, const clue::CLUECalorimeterHit& value) {
+  o << "Energy: " << value.getEnergy() << "\n"
+    << "Time: " << value.getTime() << "\n"
+    << "Position: (" << value.getPosition().x << ", " << value.getPosition().y << ", " << value.getPosition().z << ")\n"
+    << "Layer: " << value.getLayer() << "\n"
+    << "Region: " << (value.inBarrel() ? "Barrel" : "Endcap") << "\n"
+    << "Status: "
+    << (value.isSeed()       ? "Seed"
+        : value.isFollower() ? "Follower"
+                             : "Outlier")
+    << "\n"
+    << "Rho: " << value.getRho() << "\n"
+    << "Delta: " << value.getDelta() << "\n"
+    << "Cluster Index: " << value.getClusterIndex() << "\n";
+  return o;
+}

--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -176,6 +176,7 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
       m_clhits_y.push_back(hit.getPosition().y);
       m_clhits_z.push_back(hit.getPosition().z);
       m_clhits_energy.push_back(hit.getEnergy());
+      m_clhits_id.push_back(nClusters);
       totEnergyHits += hit.getEnergy();
       totSize += 1;
       /*
@@ -202,18 +203,21 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
   info() << ClusterCollectionName << " : Total number hits = " << totSize << " with total energy (cl) = " << totEnergy
          << "; (hits) = " << totEnergyHits << endmsg;
 
+  const auto& clue_calo_coll_vect = clue_calo_coll->vect;
+
   std::uint64_t nSeeds = 0;
   std::uint64_t nFollowers = 0;
   std::uint64_t nOutliers = 0;
   totEnergy = 0;
-  debug() << "CLUE Calorimeter Hits Size = " << clue_calo_coll->vect.size() << endmsg;
-  for (const auto& clue_hit : (clue_calo_coll->vect)) {
+  debug() << "CLUE Calorimeter Hits Size = " << clue_calo_coll_vect.size() << endmsg;
+  for (const auto& clue_hit : (clue_calo_coll_vect)) {
     m_hits_event.push_back(evNum);
     if (clue_hit.inBarrel()) {
       m_hits_region.push_back(0);
     } else {
       m_hits_region.push_back(1);
     }
+    m_hits_clusId.push_back(clue_hit.getClusterIndex());
     m_hits_layer.push_back(clue_hit.getLayer());
     m_hits_x.push_back(clue_hit.getPosition().x);
     m_hits_y.push_back(clue_hit.getPosition().y);
@@ -252,6 +256,7 @@ void CLUENtuplizer::initializeTrees() {
   t_hits->Branch("region", &m_hits_region);
   t_hits->Branch("layer", &m_hits_layer);
   t_hits->Branch("status", &m_hits_status);
+  t_hits->Branch("clusterId", &m_hits_clusId);
   t_hits->Branch("x", &m_hits_x);
   t_hits->Branch("y", &m_hits_y);
   t_hits->Branch("z", &m_hits_z);
@@ -281,6 +286,7 @@ void CLUENtuplizer::initializeTrees() {
   t_clhits->Branch("y", &m_clhits_y);
   t_clhits->Branch("z", &m_clhits_z);
   t_clhits->Branch("energy", &m_clhits_energy);
+  t_clhits->Branch("clusterId", &m_clhits_id);
 
   return;
 }
@@ -290,6 +296,7 @@ void CLUENtuplizer::cleanTrees() const {
   m_hits_region.clear();
   m_hits_layer.clear();
   m_hits_status.clear();
+  m_hits_clusId.clear();
   m_hits_x.clear();
   m_hits_y.clear();
   m_hits_z.clear();
@@ -319,6 +326,7 @@ void CLUENtuplizer::cleanTrees() const {
   m_clhits_y.clear();
   m_clhits_z.clear();
   m_clhits_energy.clear();
+  m_clhits_id.clear();
 
   return;
 }

--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -126,13 +126,13 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
 
   info() << ClusterCollectionName << " : Total number of clusters =  " << int(cluster_coll->size()) << endmsg;
   for (const auto& cl : *cluster_coll) {
-    m_clusters_event->push_back(evNum);
-    m_clusters_energy->push_back(cl.getEnergy());
-    m_clusters_size->push_back(cl.hits_size());
+    m_clusters_event.push_back(evNum);
+    m_clusters_energy.push_back(cl.getEnergy());
+    m_clusters_size.push_back(cl.hits_size());
 
-    m_clusters_x->push_back(cl.getPosition().x);
-    m_clusters_y->push_back(cl.getPosition().y);
-    m_clusters_z->push_back(cl.getPosition().z);
+    m_clusters_x.push_back(cl.getPosition().x);
+    m_clusters_y.push_back(cl.getPosition().y);
+    m_clusters_z.push_back(cl.getPosition().z);
 
     // Sum up energy of cluster hits and save info
     // Printout the hits that are in Ecal but not included in the clusters
@@ -170,12 +170,12 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
       // info() << "  ch cellID : " << hit.getCellID()
       //        << ", layer : " << ch_layer
       //        << ", energy : " << hit.getEnergy() << endmsg;
-      m_clhits_event->push_back(evNum);
-      m_clhits_layer->push_back(ch_layer);
-      m_clhits_x->push_back(hit.getPosition().x);
-      m_clhits_y->push_back(hit.getPosition().y);
-      m_clhits_z->push_back(hit.getPosition().z);
-      m_clhits_energy->push_back(hit.getEnergy());
+      m_clhits_event.push_back(evNum);
+      m_clhits_layer.push_back(ch_layer);
+      m_clhits_x.push_back(hit.getPosition().x);
+      m_clhits_y.push_back(hit.getPosition().y);
+      m_clhits_z.push_back(hit.getPosition().z);
+      m_clhits_energy.push_back(hit.getEnergy());
       totEnergyHits += hit.getEnergy();
       totSize += 1;
       /*
@@ -190,13 +190,13 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
     if (!std::isnan(cl.getEnergy())) {
       totEnergy += cl.getEnergy();
     }
-    m_clusters_maxLayer->push_back(maxLayer);
+    m_clusters_maxLayer.push_back(maxLayer);
   }
-  m_clusters->push_back(nClusters);
-  m_clusters_totEnergy->push_back(totEnergy);
-  m_clusters_totEnergyHits->push_back(totEnergyHits);
-  m_clusters_MCEnergy->push_back(mcp_primary_energy);
-  m_clusters_totSize->push_back(totSize);
+  m_clusters.push_back(nClusters);
+  m_clusters_totEnergy.push_back(totEnergy);
+  m_clusters_totEnergyHits.push_back(totEnergyHits);
+  m_clusters_MCEnergy.push_back(mcp_primary_energy);
+  m_clusters_totSize.push_back(totSize);
   t_clusters->Fill();
   t_clhits->Fill();
   info() << ClusterCollectionName << " : Total number hits = " << totSize << " with total energy (cl) = " << totEnergy
@@ -208,36 +208,36 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
   totEnergy = 0;
   debug() << "CLUE Calorimeter Hits Size = " << clue_calo_coll->vect.size() << endmsg;
   for (const auto& clue_hit : (clue_calo_coll->vect)) {
-    m_hits_event->push_back(evNum);
+    m_hits_event.push_back(evNum);
     if (clue_hit.inBarrel()) {
-      m_hits_region->push_back(0);
+      m_hits_region.push_back(0);
     } else {
-      m_hits_region->push_back(1);
+      m_hits_region.push_back(1);
     }
-    m_hits_layer->push_back(clue_hit.getLayer());
-    m_hits_x->push_back(clue_hit.getPosition().x);
-    m_hits_y->push_back(clue_hit.getPosition().y);
-    m_hits_z->push_back(clue_hit.getPosition().z);
-    m_hits_eta->push_back(clue_hit.getEta());
-    m_hits_phi->push_back(clue_hit.getPhi());
-    m_hits_rho->push_back(clue_hit.getRho());
-    m_hits_delta->push_back(clue_hit.getDelta());
-    m_hits_energy->push_back(clue_hit.getEnergy());
-    m_hits_MCEnergy->push_back(mcp_primary_energy);
+    m_hits_layer.push_back(clue_hit.getLayer());
+    m_hits_x.push_back(clue_hit.getPosition().x);
+    m_hits_y.push_back(clue_hit.getPosition().y);
+    m_hits_z.push_back(clue_hit.getPosition().z);
+    m_hits_eta.push_back(clue_hit.getEta());
+    m_hits_phi.push_back(clue_hit.getPhi());
+    m_hits_rho.push_back(clue_hit.getRho());
+    m_hits_delta.push_back(clue_hit.getDelta());
+    m_hits_energy.push_back(clue_hit.getEnergy());
+    m_hits_MCEnergy.push_back(mcp_primary_energy);
 
     if (clue_hit.isFollower()) {
-      m_hits_status->push_back(1);
+      m_hits_status.push_back(1);
       totEnergy += clue_hit.getEnergy();
       nFollowers++;
     }
     if (clue_hit.isSeed()) {
-      m_hits_status->push_back(2);
+      m_hits_status.push_back(2);
       totEnergy += clue_hit.getEnergy();
       nSeeds++;
     }
 
     if (clue_hit.isOutlier()) {
-      m_hits_status->push_back(0);
+      m_hits_status.push_back(0);
       nOutliers++;
     }
   }
@@ -248,21 +248,6 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
 }
 
 void CLUENtuplizer::initializeTrees() {
-
-  m_hits_event = new std::vector<int>();
-  m_hits_region = new std::vector<int>();
-  m_hits_layer = new std::vector<int>();
-  m_hits_status = new std::vector<int>();
-  m_hits_x = new std::vector<float>();
-  m_hits_y = new std::vector<float>();
-  m_hits_z = new std::vector<float>();
-  m_hits_eta = new std::vector<float>();
-  m_hits_phi = new std::vector<float>();
-  m_hits_rho = new std::vector<float>();
-  m_hits_delta = new std::vector<float>();
-  m_hits_energy = new std::vector<float>();
-  m_hits_MCEnergy = new std::vector<float>();
-
   t_hits->Branch("event", &m_hits_event);
   t_hits->Branch("region", &m_hits_region);
   t_hits->Branch("layer", &m_hits_layer);
@@ -277,19 +262,6 @@ void CLUENtuplizer::initializeTrees() {
   t_hits->Branch("energy", &m_hits_energy);
   t_hits->Branch("MCEnergy", &m_hits_MCEnergy);
 
-  m_clusters = new std::vector<int>();
-  m_clusters_event = new std::vector<int>();
-  m_clusters_maxLayer = new std::vector<int>();
-  m_clusters_size = new std::vector<int>();
-  m_clusters_totSize = new std::vector<int>();
-  m_clusters_x = new std::vector<float>();
-  m_clusters_y = new std::vector<float>();
-  m_clusters_z = new std::vector<float>();
-  m_clusters_energy = new std::vector<float>();
-  m_clusters_totEnergy = new std::vector<float>();
-  m_clusters_totEnergyHits = new std::vector<float>();
-  m_clusters_MCEnergy = new std::vector<float>();
-
   t_clusters->Branch("clusters", &m_clusters);
   t_clusters->Branch("event", &m_clusters_event);
   t_clusters->Branch("maxLayer", &m_clusters_maxLayer);
@@ -303,13 +275,6 @@ void CLUENtuplizer::initializeTrees() {
   t_clusters->Branch("totEnergyHits", &m_clusters_totEnergyHits);
   t_clusters->Branch("MCEnergy", &m_clusters_MCEnergy);
 
-  m_clhits_event = new std::vector<int>();
-  m_clhits_layer = new std::vector<int>();
-  m_clhits_x = new std::vector<float>();
-  m_clhits_y = new std::vector<float>();
-  m_clhits_z = new std::vector<float>();
-  m_clhits_energy = new std::vector<float>();
-
   t_clhits->Branch("event", &m_clhits_event);
   t_clhits->Branch("layer", &m_clhits_layer);
   t_clhits->Branch("x", &m_clhits_x);
@@ -321,39 +286,39 @@ void CLUENtuplizer::initializeTrees() {
 }
 
 void CLUENtuplizer::cleanTrees() const {
-  m_hits_event->clear();
-  m_hits_region->clear();
-  m_hits_layer->clear();
-  m_hits_status->clear();
-  m_hits_x->clear();
-  m_hits_y->clear();
-  m_hits_z->clear();
-  m_hits_eta->clear();
-  m_hits_phi->clear();
-  m_hits_rho->clear();
-  m_hits_delta->clear();
-  m_hits_energy->clear();
-  m_hits_MCEnergy->clear();
+  m_hits_event.clear();
+  m_hits_region.clear();
+  m_hits_layer.clear();
+  m_hits_status.clear();
+  m_hits_x.clear();
+  m_hits_y.clear();
+  m_hits_z.clear();
+  m_hits_eta.clear();
+  m_hits_phi.clear();
+  m_hits_rho.clear();
+  m_hits_delta.clear();
+  m_hits_energy.clear();
+  m_hits_MCEnergy.clear();
 
-  m_clusters->clear();
-  m_clusters_event->clear();
-  m_clusters_maxLayer->clear();
-  m_clusters_size->clear();
-  m_clusters_totSize->clear();
-  m_clusters_x->clear();
-  m_clusters_y->clear();
-  m_clusters_z->clear();
-  m_clusters_energy->clear();
-  m_clusters_totEnergy->clear();
-  m_clusters_totEnergyHits->clear();
-  m_clusters_MCEnergy->clear();
+  m_clusters.clear();
+  m_clusters_event.clear();
+  m_clusters_maxLayer.clear();
+  m_clusters_size.clear();
+  m_clusters_totSize.clear();
+  m_clusters_x.clear();
+  m_clusters_y.clear();
+  m_clusters_z.clear();
+  m_clusters_energy.clear();
+  m_clusters_totEnergy.clear();
+  m_clusters_totEnergyHits.clear();
+  m_clusters_MCEnergy.clear();
 
-  m_clhits_event->clear();
-  m_clhits_layer->clear();
-  m_clhits_x->clear();
-  m_clhits_y->clear();
-  m_clhits_z->clear();
-  m_clhits_energy->clear();
+  m_clhits_event.clear();
+  m_clhits_layer.clear();
+  m_clhits_x.clear();
+  m_clhits_y.clear();
+  m_clhits_z.clear();
+  m_clhits_energy.clear();
 
   return;
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- add `operator<<`, reorder class members and do not return `const&` for simple types in `CLUECalorimeterHit`
- use `std::vector<T>` instead of `std::vector<T>*` and add the cluster index to each hit in the `CLUENtuplizer`
- use the file downloaded when building the repo in `clue_gaudi_wrapper.py`

ENDRELEASENOTES

