### PR TITLE
Move DataHandle and MetaDataHandle to the k4FWCore namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(GNUInstallDirs)
 find_package(DD4hep REQUIRED)
 find_package(EDM4HEP REQUIRED)
 
-find_package(k4FWCore REQUIRED)
+find_package(k4FWCore 1.3 REQUIRED)
 find_package(Gaudi REQUIRED)
 
 include(CTest)

--- a/include/CLUENtuplizer.h
+++ b/include/CLUENtuplizer.h
@@ -56,13 +56,16 @@ private:
   mutable const edm4hep::ClusterCollection* cluster_coll;
   mutable const edm4hep::CalorimeterHitCollection* EB_calo_coll;
   mutable const edm4hep::CalorimeterHitCollection* EE_calo_coll;
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> EB_calo_handle{"BarrelInputHits", Gaudi::DataHandle::Reader,
-                                                                       this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle{"EndcapInputHits", Gaudi::DataHandle::Reader,
-                                                                       this};
-  mutable DataHandle<edm4hep::EventHeaderCollection> ev_handle{"EventHeader", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<edm4hep::MCParticleCollection> mcp_handle{"MCParticles", Gaudi::DataHandle::Reader, this};
-  MetaDataHandle<std::string> cellIDHandle{EB_calo_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> EB_calo_handle{"BarrelInputHits",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle{"EndcapInputHits",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::EventHeaderCollection> ev_handle{"EventHeader", Gaudi::DataHandle::Reader,
+                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> mcp_handle{"MCParticles", Gaudi::DataHandle::Reader,
+                                                                         this};
+  k4FWCore::MetaDataHandle<std::string> cellIDHandle{EB_calo_handle, edm4hep::labels::CellIDEncoding,
+                                                     Gaudi::DataHandle::Reader};
 
   bool singleMCParticle = false;
 

--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -108,8 +108,8 @@ StatusCode CLUENtuplizer::execute(const EventContext&) const {
   // Read cluster collection
   // This should be fixed, for now the const cast is added to be able to create the handle
   // as it was done before https://github.com/key4hep/k4Clue/pull/60
-  DataHandle<edm4hep::ClusterCollection> cluster_handle{ClusterCollectionName, Gaudi::DataHandle::Reader,
-                                                        const_cast<CLUENtuplizer*>(this)};
+  k4FWCore::DataHandle<edm4hep::ClusterCollection> cluster_handle{ClusterCollectionName, Gaudi::DataHandle::Reader,
+                                                                  const_cast<CLUENtuplizer*>(this)};
   cluster_coll = cluster_handle.get();
 
   // Get collection metadata cellID which is valid for both EB, EE and Clusters

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -70,20 +70,22 @@ private:
   mutable std::vector<float> weight;
 
   // Handle to read the calo cells and their cellID
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> EB_calo_handle{"BarrelInputHits", Gaudi::DataHandle::Reader,
-                                                                       this};
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle{"EndcapInputHits", Gaudi::DataHandle::Reader,
-                                                                       this};
-  MetaDataHandle<std::string> cellIDHandle{EB_calo_handle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> EB_calo_handle{"BarrelInputHits",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> EE_calo_handle{"EndcapInputHits",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  k4FWCore::MetaDataHandle<std::string> cellIDHandle{EB_calo_handle, edm4hep::labels::CellIDEncoding,
+                                                     Gaudi::DataHandle::Reader};
 
   // CLUE Algo
   mutable CLICdetBarrelCLUEAlgo clueAlgoBarrel_;
   mutable CLICdetEndcapCLUEAlgo clueAlgoEndcap_;
 
   // Collections in output
-  mutable DataHandle<edm4hep::CalorimeterHitCollection> caloHitsHandle{"CLUEClustersAsHits", Gaudi::DataHandle::Writer,
-                                                                       this};
-  mutable DataHandle<edm4hep::ClusterCollection> clustersHandle{"CLUEClusters", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::CalorimeterHitCollection> caloHitsHandle{"CLUEClustersAsHits",
+                                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ClusterCollection> clustersHandle{"CLUEClusters", Gaudi::DataHandle::Writer,
+                                                                          this};
 };
 
 #endif


### PR DESCRIPTION
BEGINRELEASENOTES
- Move DataHandle and MetaDataHandle to the k4FWCore namespace, done in k4FWCore in https://github.com/key4hep/k4FWCore/pull/317
- Bump the required version of k4FWCore

ENDRELEASENOTES