### PR TITLE
Use the ubuntu-latest image for the pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3.1


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the ubuntu-latest image for the pre-commit workflow

ENDRELEASENOTES

Let's assume there is a stack with the latest ubuntu, which is typically true by the time ubuntu-latest updates to the most recent Ubuntu.