### PR TITLE
Properly propagate input cellID encodings to outputs

### DIFF
--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 from Gaudi.Configuration import WARNING, INFO
-from Configurables import ClueGaudiAlgorithmWrapper3D, CLUENtuplizer, THistSvc, EventDataSvc
+from Configurables import ClueGaudiAlgorithmWrapper3D, CLUENtuplizer, THistSvc, EventDataSvc, MetadataSvc
 from k4FWCore import ApplicationMgr, IOSvc
 
 iosvc = IOSvc()
@@ -54,6 +54,6 @@ THistSvc().AutoFlush = True
 ApplicationMgr( TopAlg = [MyClueGaudiAlgorithmWrapper, MyCLUENtuplizer],
                 EvtSel = 'NONE',
                 EvtMax   = 3,
-                ExtSvc = [EventDataSvc("EventDataSvc")],
+                ExtSvc = [EventDataSvc("EventDataSvc"), MetadataSvc("MetadataSvc")],
                 OutputLevel=WARNING
               )

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -316,10 +316,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_c
                                                     const CaloHitColl& EE_calo_coll) const {
 
   // Get collection metadata cellID which is valid for both EB and EE
-  const std::string cellIDstr =
-      k4FWCore::getParameter<std::string>(
-          podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
-          .value_or("");
+  const std::string cellIDstr = k4FWCore::getCellIDEncoding("EcalBarrelCollection", this).value_or("");
   const BitFieldCoder bf(cellIDstr);
 
   // Output CLUE clusters

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -53,7 +53,8 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   info() << "CLUEAlgo will run on device " << alpaka::getName(alpaka::getDev(*m_queue)) << endmsg;
 
   // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
-  const std::string cellIDstr = k4FWCore::getCellIDEncoding("EcalBarrelCollection", this).value_or("");
+  const std::string cellIDstr =
+      k4FWCore::getCellIDEncoding(inputLocations("BarrelCaloHitsCollection")[0], this).value_or("");
   for (auto i = 0u; i < outputLocationsSize(); ++i)
     k4FWCore::putCellIDEncoding(outputLocations(i)[0], cellIDstr, this);
 
@@ -323,7 +324,8 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_c
                                                     const CaloHitColl& EE_calo_coll) const {
 
   // Get collection metadata cellID which is valid for both EB and EE
-  const std::string cellIDstr = k4FWCore::getCellIDEncoding("EcalBarrelCollection", this).value_or("");
+  const std::string cellIDstr =
+      k4FWCore::getCellIDEncoding(inputLocations("BarrelCaloHitsCollection")[0], this).value_or("");
   const BitFieldCoder bf(cellIDstr);
 
   // Output CLUE clusters

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -23,6 +23,8 @@
 // podio specific includes
 #include "DDSegmentation/BitFieldCoder.h"
 
+#include <k4FWCore/MetadataUtils.h>
+
 using namespace dd4hep;
 using namespace DDSegmentation;
 
@@ -49,6 +51,11 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   std::chrono::duration<double> elapsed = finish - start;
   debug() << "ClueGaudiAlgorithmWrapper: Set up time: " << elapsed.count() * 1000 << " ms" << endmsg;
   info() << "CLUEAlgo will run on device " << alpaka::getName(alpaka::getDev(*m_queue)) << endmsg;
+
+  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
+  const std::string cellIDstr = k4FWCore::getCellIDEncoding("EcalBarrelCollection", this).value_or("");
+  for (auto i = 0u; i < outputLocationsSize(); ++i)
+    k4FWCore::putCellIDEncoding(outputLocations(i)[0], cellIDstr, this);
 
   return Algorithm::initialize();
 }
@@ -393,10 +400,6 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_c
   auto finalCaloHits = CaloHitColl();
   transformClustersInCaloHits(finalClusters, finalCaloHits);
   debug() << "Saved " << finalCaloHits.size() << " clusters as calo hits" << endmsg;
-
-  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
-  for (auto i = 0u; i < outputLocationsSize(); ++i)
-    k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);
 
   // Cleaning
   clue_hit_coll.vect.clear();


### PR DESCRIPTION
BEGINRELEASENOTES
- Set the CellID encoding string in `initialize` as doing it during the event loop will no longer work (see [key4hep/k4FWCore#400](https://github.com/key4hep/k4FWCore/pull/400)
- Switch to the newly available utilities for setting the cell id encoding (key4hep/k4FWCore#391](https://github.com/key4hep/k4FWCore/pull/391))
- Propagate the cell id encoding of the input collection downstream instead of using a hardcoded collection name.

ENDRELEASENOTES


Noticed this in the downstream build of k4MarlinWrapper