### PR TITLE
Add different clustering strategies and different coordinates 

### DIFF
--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -35,7 +35,8 @@ MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWra
     CriticalDistance = dc,
     MinLocalDensity = rho,
     FollowerDistance = dm,
-    OutputLevel = INFO
+    OutputLevel = INFO,
+    strategy = "PerDetectorRegion", # "PerCollection" #
 )
 
 MyCLUENtuplizer = CLUENtuplizer("CLUEAnalysis",

--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -36,6 +36,7 @@ MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWra
     OutputLevel = INFO,
     strategy = "MergeCollections", # "PerDetectorRegion", "PerCollection" , "MergeCollections"
     coordinate = "Polar", # "Cartesian"
+    SaveClustersAsHits = True,
 )
 
 MyCLUENtuplizer = CLUENtuplizer("CLUEAnalysis",

--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -29,15 +29,13 @@ rho = 0.1
 dm = 120
 
 MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWrapperName",
-    #BarrelCaloHitsCollection = ["ECALBarrel", "HCALBarrel"],
-    #EndcapCaloHitsCollection = ["ECALEndcap", "HCALEndcap"],
     CaloHitsCollections = ["ECALBarrel", "HCALBarrel", "ECALEndcap", "HCALEndcap"],
     CriticalDistance = dc,
     MinLocalDensity = rho,
     FollowerDistance = dm,
     OutputLevel = INFO,
-    strategy = "PerDetectorRegion", # "PerCollection" #
-    coordinate = "Polar", #"Cartesian"
+    strategy = "MergeCollections", # "PerDetectorRegion", "PerCollection" , "MergeCollections"
+    coordinate = "Polar", # "Cartesian"
 )
 
 MyCLUENtuplizer = CLUENtuplizer("CLUEAnalysis",

--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -29,8 +29,9 @@ rho = 0.1
 dm = 120
 
 MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWrapperName",
-    BarrelCaloHitsCollection = ["ECALBarrel", "HCALBarrel"],
-    EndcapCaloHitsCollection = ["ECALEndcap", "HCALEndcap"],
+    #BarrelCaloHitsCollection = ["ECALBarrel", "HCALBarrel"],
+    #EndcapCaloHitsCollection = ["ECALEndcap", "HCALEndcap"],
+    CaloHitsCollections = ["ECALBarrel", "HCALBarrel", "ECALEndcap", "HCALEndcap"],
     CriticalDistance = dc,
     MinLocalDensity = rho,
     FollowerDistance = dm,

--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -29,8 +29,8 @@ rho = 0.1
 dm = 120
 
 MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWrapperName",
-    BarrelCaloHitsCollection = "ECALBarrel",
-    EndcapCaloHitsCollection = "ECALEndcap",
+    BarrelCaloHitsCollection = ["ECALBarrel", "HCALBarrel"],
+    EndcapCaloHitsCollection = ["ECALEndcap", "HCALEndcap"],
     CriticalDistance = dc,
     MinLocalDensity = rho,
     FollowerDistance = dm,
@@ -38,8 +38,6 @@ MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWra
 )
 
 MyCLUENtuplizer = CLUENtuplizer("CLUEAnalysis",
-    BarrelCaloHitsCollection = ["ECALBarrel"],
-    EndcapCaloHitsCollection = ["ECALEndcap"],
     OutputLevel = WARNING
 )
 

--- a/gaudi_opts/clue_gaudi_wrapper.py
+++ b/gaudi_opts/clue_gaudi_wrapper.py
@@ -37,6 +37,7 @@ MyClueGaudiAlgorithmWrapper = ClueGaudiAlgorithmWrapper3D("ClueGaudiAlgorithmWra
     FollowerDistance = dm,
     OutputLevel = INFO,
     strategy = "PerDetectorRegion", # "PerCollection" #
+    coordinate = "Polar", #"Cartesian"
 )
 
 MyCLUENtuplizer = CLUENtuplizer("CLUEAnalysis",

--- a/include/CLUECalorimeterHit.h
+++ b/include/CLUECalorimeterHit.h
@@ -65,26 +65,14 @@ public:
   /// Access the rho
   float getRho() const;
 
-  /// Access the transverse position
-  float getR() const;
-
-  /// Access the eta
-  float getEta() const;
-
-  /// Access the theta
-  float getTheta() const;
-
-  /// Access the phi
-  float getPhi() const;
-
   /// Access cluster index
   int32_t getClusterIndex() const;
 
-  /// Set hit transverse global position, pseudorapidity and phi
-  void setR();
-  void setEta();
-  void setTheta();
-  void setPhi();
+  /// Access to polar & pseudorapidity coordinates
+  float getR() const;
+  float getTheta() const;
+  float getPhi() const;
+  float getEta() const;
 
   void setRho(float rho) { m_rho = rho; }
   void setDelta(float delta) { m_delta = delta; }
@@ -92,10 +80,6 @@ public:
   void setClusterIndex(int32_t clIdx) { m_clusterIndex = clIdx; }
 
 private:
-  float m_r;
-  float m_eta;
-  float m_theta;
-  float m_phi;
   float m_rho;
   float m_delta;
   uint8_t m_detectorRegion;

--- a/include/CLUECalorimeterHit.h
+++ b/include/CLUECalorimeterHit.h
@@ -71,6 +71,9 @@ public:
   /// Access the eta
   float getEta() const;
 
+  /// Access the theta
+  float getTheta() const;
+
   /// Access the phi
   float getPhi() const;
 
@@ -80,6 +83,7 @@ public:
   /// Set hit transverse global position, pseudorapidity and phi
   void setR();
   void setEta();
+  void setTheta();
   void setPhi();
 
   void setRho(float rho) { m_rho = rho; }
@@ -88,9 +92,10 @@ public:
   void setClusterIndex(int32_t clIdx) { m_clusterIndex = clIdx; }
 
 private:
-  float m_eta;
-  float m_phi;
   float m_r;
+  float m_eta;
+  float m_theta;
+  float m_phi;
   float m_rho;
   float m_delta;
   uint8_t m_detectorRegion;

--- a/include/CLUENtuplizer.h
+++ b/include/CLUENtuplizer.h
@@ -35,22 +35,18 @@
 #include "TH1F.h"
 #include "TTree.h"
 
-using CaloHitColl = edm4hep::CalorimeterHitCollection;
 using ClueHitColl = clue::CLUECalorimeterHitCollection;
 using ClusterColl = edm4hep::ClusterCollection;
 using MCPartColl = edm4hep::MCParticleCollection;
 using ClusterMCLinkColl = edm4hep::ClusterMCParticleLinkCollection;
 
 struct CLUENtuplizer final
-    : k4FWCore::Consumer<void(const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll,
-                              const ClusterColl& cluster_coll, const edm4hep::EventHeaderCollection& ev_handle,
+    : k4FWCore::Consumer<void(const ClusterColl& cluster_coll, const edm4hep::EventHeaderCollection& ev_handle,
                               const MCPartColl& mcp_handle, const ClusterMCLinkColl& clustersLink_handle)> {
   CLUENtuplizer(const std::string& name, ISvcLocator* svcLoc)
       : Consumer(name, svcLoc,
-                 {KeyValues("BarrelCaloHitsCollection", {"ECALBarrel"}),
-                  KeyValues("EndcapCaloHitsCollection", {"ECALEndcap"}), KeyValues("InputClusters", {"CLUEClusters"}),
-                  KeyValue("EventHeader", "EventHeader"), KeyValue("MCParticles", "MCParticles"),
-                  KeyValues("ClusterLinks", {"ClusterMCTruthLink"})}) {}
+                 {KeyValue("InputClusters", "CLUEClusters"), KeyValue("EventHeader", "EventHeader"),
+                  KeyValue("MCParticles", "MCParticles"), KeyValue("ClusterLinks", "ClusterMCTruthLink")}) {}
 
   /// Initialize.
   StatusCode initialize() override;
@@ -61,8 +57,7 @@ struct CLUENtuplizer final
   /// Finalize.
   StatusCode finalize() override;
 
-  void operator()(const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll, const ClusterColl& cluster_coll,
-                  const edm4hep::EventHeaderCollection& evs, const MCPartColl& mcps,
+  void operator()(const ClusterColl& cluster_coll, const edm4hep::EventHeaderCollection& evs, const MCPartColl& mcps,
                   const ClusterMCLinkColl& linksClus) const override;
 
 private:

--- a/src/CLUECalorimeterHit.cpp
+++ b/src/CLUECalorimeterHit.cpp
@@ -21,32 +21,17 @@
 
 namespace clue {
 
-CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch) : CalorimeterHit(ch) {
-  setR();
-  setEta();
-  setTheta();
-  setPhi();
-}
+CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch) : CalorimeterHit(ch) {}
 
 CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalorimeterHit::DetectorRegion detRegion,
                                        const int layer)
-    : CalorimeterHit(ch), m_detectorRegion(detRegion), m_layer(layer) {
-  setR();
-  setEta();
-  setTheta();
-  setPhi();
-}
+    : CalorimeterHit(ch), m_detectorRegion(detRegion), m_layer(layer) {}
 
 CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalorimeterHit::DetectorRegion detRegion,
                                        const int layer, const CLUECalorimeterHit::Status status, const int clusterIndex,
                                        const float rho, const float delta)
     : CalorimeterHit(ch), m_rho(rho), m_delta(delta), m_detectorRegion(detRegion), m_status(status), m_layer(layer),
-      m_clusterIndex(clusterIndex) {
-  setR();
-  setEta();
-  setTheta();
-  setPhi();
-}
+      m_clusterIndex(clusterIndex) {}
 
 uint32_t CLUECalorimeterHit::getLayer() const { return m_layer; }
 bool CLUECalorimeterHit::inBarrel() const { return (m_detectorRegion == barrel ? true : false); }
@@ -56,24 +41,36 @@ bool CLUECalorimeterHit::isSeed() const { return (m_status == seed ? true : fals
 bool CLUECalorimeterHit::isOutlier() const { return (m_status == outlier ? true : false); }
 float CLUECalorimeterHit::getRho() const { return m_rho; }
 float CLUECalorimeterHit::getDelta() const { return m_delta; }
-float CLUECalorimeterHit::getR() const { return m_r; }
-float CLUECalorimeterHit::getEta() const { return m_eta; }
-float CLUECalorimeterHit::getTheta() const { return m_theta; }
-float CLUECalorimeterHit::getPhi() const { return m_phi; }
 int32_t CLUECalorimeterHit::getClusterIndex() const { return m_clusterIndex; };
 
-void CLUECalorimeterHit::setEta() { m_eta = -1. * log(tan(atan2(m_r, getPosition().z) / 2.)); }
-
-void CLUECalorimeterHit::setTheta() {
-  float r = std::sqrt(getPosition().x * getPosition().x + getPosition().y * getPosition().y +
-                      getPosition().z * getPosition().z);
-  m_theta = (r > 0) ? std::acos(getPosition().z / r) : 0.0f;
+float CLUECalorimeterHit::getR() const {
+  const auto pos = getPosition();
+  return float(sqrt(pos.x * pos.x + pos.y * pos.y + pos.z * pos.z));
 }
 
-void CLUECalorimeterHit::setPhi() { m_phi = atan2(getPosition().y, getPosition().x); }
+float CLUECalorimeterHit::getTheta() const {
+  const auto pos = getPosition();
+  float r = getR();
+  return (r > 0) ? float(std::acos(pos.z / r)) : 0.0f;
+}
 
-void CLUECalorimeterHit::setR() {
-  m_r = float(sqrt(getPosition().x * getPosition().x + getPosition().y * getPosition().y));
+float CLUECalorimeterHit::getPhi() const {
+  const auto pos = getPosition();
+  return atan2(pos.y, pos.x);
+}
+
+float CLUECalorimeterHit::getEta() const {
+  float theta = getTheta();
+
+  if (theta <= 0) {
+    // return a large value for eta
+    return std::numeric_limits<float>::infinity();
+  } else if (theta >= M_PI) {
+    // return a large negative value for eta
+    return -std::numeric_limits<float>::infinity();
+  }
+
+  return -1. * float(log(tan(theta / 2.)));
 }
 
 } // namespace clue

--- a/src/CLUECalorimeterHit.cpp
+++ b/src/CLUECalorimeterHit.cpp
@@ -65,7 +65,8 @@ int32_t CLUECalorimeterHit::getClusterIndex() const { return m_clusterIndex; };
 void CLUECalorimeterHit::setEta() { m_eta = -1. * log(tan(atan2(m_r, getPosition().z) / 2.)); }
 
 void CLUECalorimeterHit::setTheta() {
-  float r = std::sqrt(getPosition().x * getPosition().x + getPosition().y * getPosition().y + getPosition().z * getPosition().z);
+  float r = std::sqrt(getPosition().x * getPosition().x + getPosition().y * getPosition().y +
+                      getPosition().z * getPosition().z);
   m_theta = (r > 0) ? std::acos(getPosition().z / r) : 0.0f;
 }
 

--- a/src/CLUECalorimeterHit.cpp
+++ b/src/CLUECalorimeterHit.cpp
@@ -24,6 +24,7 @@ namespace clue {
 CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch) : CalorimeterHit(ch) {
   setR();
   setEta();
+  setTheta();
   setPhi();
 }
 
@@ -32,6 +33,7 @@ CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalor
     : CalorimeterHit(ch), m_detectorRegion(detRegion), m_layer(layer) {
   setR();
   setEta();
+  setTheta();
   setPhi();
 }
 
@@ -42,6 +44,7 @@ CLUECalorimeterHit::CLUECalorimeterHit(const CalorimeterHit& ch, const CLUECalor
       m_clusterIndex(clusterIndex) {
   setR();
   setEta();
+  setTheta();
   setPhi();
 }
 
@@ -55,10 +58,16 @@ float CLUECalorimeterHit::getRho() const { return m_rho; }
 float CLUECalorimeterHit::getDelta() const { return m_delta; }
 float CLUECalorimeterHit::getR() const { return m_r; }
 float CLUECalorimeterHit::getEta() const { return m_eta; }
+float CLUECalorimeterHit::getTheta() const { return m_theta; }
 float CLUECalorimeterHit::getPhi() const { return m_phi; }
 int32_t CLUECalorimeterHit::getClusterIndex() const { return m_clusterIndex; };
 
 void CLUECalorimeterHit::setEta() { m_eta = -1. * log(tan(atan2(m_r, getPosition().z) / 2.)); }
+
+void CLUECalorimeterHit::setTheta() {
+  float r = std::sqrt(getPosition().x * getPosition().x + getPosition().y * getPosition().y + getPosition().z * getPosition().z);
+  m_theta = (r > 0) ? std::acos(getPosition().z / r) : 0.0f;
+}
 
 void CLUECalorimeterHit::setPhi() { m_phi = atan2(getPosition().y, getPosition().x); }
 

--- a/src/CLUENtuplizer.cpp
+++ b/src/CLUENtuplizer.cpp
@@ -75,10 +75,8 @@ StatusCode CLUENtuplizer::initialize() {
   return StatusCode::SUCCESS;
 }
 
-void CLUENtuplizer::operator()(const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll,
-                               const ClusterColl& cluster_coll,
-                               const edm4hep::EventHeaderCollection& evs, const MCPartColl& mcps,
-                               const ClusterMCLinkColl& linksClus) const {
+void CLUENtuplizer::operator()(const ClusterColl& cluster_coll, const edm4hep::EventHeaderCollection& evs,
+                               const MCPartColl& mcps, const ClusterMCLinkColl& linksClus) const {
   const std::string ClusterCollectionName = inputLocations("InputClusters")[0];
   evNum = evs[0].getEventNumber();
   info() << "Event number = " << evNum << endmsg;
@@ -92,7 +90,7 @@ void CLUENtuplizer::operator()(const CaloHitColl& EB_calo_coll, const CaloHitCol
   info() << "MC Particles = " << mcps.size() << " (of which primaries = " << mcps_primary << ")" << endmsg;
 
   DataObject* pStatus = nullptr;
-  StatusCode scStatus = eventSvc()->retrieveObject("/Event/"+m_CLUECaloHitCollName, pStatus);
+  StatusCode scStatus = eventSvc()->retrieveObject("/Event/" + m_CLUECaloHitCollName, pStatus);
   clue::CLUECalorimeterHitCollection* clue_calo_coll;
   if (scStatus.isSuccess()) {
     clue_calo_coll = static_cast<clue::CLUECalorimeterHitCollection*>(pStatus);
@@ -100,10 +98,11 @@ void CLUENtuplizer::operator()(const CaloHitColl& EB_calo_coll, const CaloHitCol
     throw std::runtime_error("CLUE hits collection not available");
   }
 
-  debug() << "All calorimeter hits Size = " << EB_calo_coll.size() + EE_calo_coll.size() << endmsg;
-
   // Get collection metadata cellID which is valid for both EB, EE and Clusters
-  const std::string cellIDstr = k4FWCore::getParameter<std::string>(podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this).value_or("");
+  const std::string cellIDstr =
+      k4FWCore::getParameter<std::string>(
+          podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
+          .value_or("");
   const BitFieldCoder bf(cellIDstr);
   cleanTrees();
 

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -29,12 +29,15 @@ using namespace dd4hep;
 using namespace DDSegmentation;
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<4>, "ClueGaudiAlgorithmWrapperCUDA4D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<3>, "ClueGaudiAlgorithmWrapperCUDA3D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<2>, "ClueGaudiAlgorithmWrapperCUDA2D")
 #elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<4>, "ClueGaudiAlgorithmWrapperHIP4D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<3>, "ClueGaudiAlgorithmWrapperHIP3D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<2>, "ClueGaudiAlgorithmWrapperHIP2D")
 #else
+DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<4>, "ClueGaudiAlgorithmWrapper4D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<3>, "ClueGaudiAlgorithmWrapper3D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<2>, "ClueGaudiAlgorithmWrapper2D")
 #endif
@@ -118,8 +121,10 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
     // } else {
     floatBuffer[i] = clue_hits[i].getPosition().x;           // Fill x coordinates
     floatBuffer[nPoints + i] = clue_hits[i].getPosition().y; // Fill y coordinates
-    if constexpr (nDim == 3)
+    if constexpr (nDim >= 3)
       floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
+    if constexpr (nDim >= 4)
+      floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime(); // Fill time coordinates
     floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy();    // Fill weights
     //}
   }

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -139,7 +139,7 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
     }
   } else if (m_coordinate == Coordinate::Polar) {
     for (size_t i = 0; i < nPoints; ++i) {
-      floatBuffer[i] = clue_hits[i].getTheta();         // Fill eta coordinates
+      floatBuffer[i] = clue_hits[i].getTheta();         // Fill theta coordinates
       floatBuffer[nPoints + i] = clue_hits[i].getPhi(); // Fill phi coordinates
       if constexpr (nDim >= 3)
         floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -70,8 +70,8 @@ template <uint8_t nDim>
 StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   m_queue = clue::get_queue(0u);
 
-  const auto seeding_distance = (m_seed_dc == -1.f) ? m_dc : m_seed_dc;
-  const auto outlier_distance = (m_dm == -1.f) ? m_dc : m_dm;
+  const auto seeding_distance = (m_seed_dc < 0.f) ? m_dc : m_seed_dc;
+  const auto outlier_distance = (m_dm < 0.f) ? m_dc : m_dm;
   auto start = std::chrono::high_resolution_clock::now();
   m_clueAlgo = std::make_optional<clue::Clusterer<nDim>>(*m_queue, m_dc, m_rhoc, outlier_distance, seeding_distance,
                                                          m_pointsPerBin);
@@ -169,10 +169,11 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
 
   if (m_coordinate == Coordinate::Cartesian) {
     for (size_t i = 0; i < nPoints; ++i) {
-      floatBuffer[i] = clue_hits[i].getPosition().x;           // Fill x coordinates
-      floatBuffer[nPoints + i] = clue_hits[i].getPosition().y; // Fill y coordinates
+      const auto& position = clue_hits[i].getPosition();
+      floatBuffer[i] = position.x;           // Fill x coordinates
+      floatBuffer[nPoints + i] = position.y; // Fill y coordinates
       if constexpr (nDim >= 3)
-        floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
+        floatBuffer[nPoints * 2 + i] = position.z; // Fill z coordinates
       if constexpr (nDim >= 4)
         floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
       floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
@@ -315,7 +316,7 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
         float maxEnergyValue = 0.f;
         float energy = 0.f;
         float sumEnergyErrSquared = 0.f;
-        for (auto index : clusterMap[cl]) {
+        for (auto index : clLay) {
           auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
           cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
@@ -463,10 +464,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
     const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
 
     // Get collection metadata cellID which is valid for both EB and EE
-    const std::string cellIDstr =
-        k4FWCore::getParameter<std::string>(
-            podio::collMetadataParamName(ClusterCollectionsNames[0], edm4hep::labels::CellIDEncoding), this)
-            .value_or("");
+    const std::string cellIDstr = k4FWCore::getCellIDEncoding(ClusterCollectionsNames[0], this).value_or("");
     const BitFieldCoder bf(cellIDstr);
 
     // Fill CLUECaloHits per region

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -57,11 +57,16 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   debug() << "ClueGaudiAlgorithmWrapper: Set up time: " << elapsed.count() * 1000 << " ms" << endmsg;
   info() << "CLUEAlgo will run on device " << alpaka::getName(alpaka::getDev(*m_queue)) << endmsg;
 
-  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
-  const std::string cellIDstr =
-      k4FWCore::getCellIDEncoding(inputLocations("BarrelCaloHitsCollection")[0], this).value_or("");
-  for (auto i = 0u; i < outputLocationsSize(); ++i)
-    k4FWCore::putCellIDEncoding(outputLocations(i)[0], cellIDstr, this);
+  if (m_strategyName == "PerDetectorRegion") {
+    m_strategy = Strategy::PerDetectorRegion;
+  } else if (m_strategyName == "MergeCollections") {
+    m_strategy = Strategy::MergeCollections;
+  } else if (m_strategyName == "PerCollection") {
+    m_strategy = Strategy::PerCollection;
+  } else {
+    error() << "Unknown strategy: " << m_strategyName << endmsg;
+    return StatusCode::FAILURE;
+  }
 
   return Algorithm::initialize();
 }
@@ -370,17 +375,13 @@ void ClueGaudiAlgorithmWrapper<nDim>::transformClustersInCaloHits(ClusterColl& c
 template <uint8_t nDim>
 retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const CaloHitColl*>& calo_coll) const {
 
-  const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
-  for (auto s : ClusterCollectionsNames)
-    std::cout <<  s << std::endl;
-
   // Output CLUE clusters
   auto finalClusters = ClusterColl();
 
   // Output CLUE calo hits
   clue::CLUECalorimeterHitCollection clue_hit_coll;
 
-  if (m_singlePass) {
+  if (m_strategy == Strategy::MergeCollections) {
     for (const auto& coll : calo_coll) {
       for (const auto& calo_hit : *coll) {
         clue_hit_coll.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
@@ -397,7 +398,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
     } else {
       info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
     }
-  } else {
+  } else if (m_strategy == Strategy::PerCollection) {
     int offset = 0;
     for (const auto& coll : calo_coll) {
       clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
@@ -420,6 +421,12 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       }
       offset += clue_hit_coll_tmp.vect.size();
     }
+  } else {
+
+  const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
+  for (auto s : ClusterCollectionsNames)
+    std::cout <<  s << std::endl;
+  // keep layers here AND LOOK for barrel/endcap in collection name
   }
 
   // Get collection metadata cellID which is valid for both EB and EE

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -28,6 +28,8 @@
 using namespace dd4hep;
 using namespace DDSegmentation;
 
+constexpr float C_MM_NS_SQUARED = 299.792458f*299.792458f;
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<4>, "ClueGaudiAlgorithmWrapperCUDA4D")
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<3>, "ClueGaudiAlgorithmWrapperCUDA3D")
@@ -143,11 +145,16 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
   auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data(), isBarrel);
 
   // Run CLUE
-  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << endmsg;
+  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << nDim << "D" << endmsg;
 
   // measure excution time of make_clusters
   auto start = std::chrono::high_resolution_clock::now();
-  m_clueAlgo->make_clusters(*m_queue, cluePoints);
+  if constexpr(nDim==4) {
+    auto metric = clue::metrics::WeightedEuclidean<nDim>(1.f, 1.f, 1.f, C_MM_NS_SQUARED);
+    m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
+  } else {
+    m_clueAlgo->make_clusters(*m_queue, cluePoints);
+  }
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finish - start;
   info() << "ClueGaudiAlgorithmWrapper: Elapsed time: " << elapsed.count() * 1000 << " ms" << endmsg;

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -44,6 +44,28 @@ DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<3>, "ClueGaudiAlgorithmWrapp
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<2>, "ClueGaudiAlgorithmWrapper2D")
 #endif
 
+namespace {
+  // Helper function to compute offsets for merged collections
+  std::vector<size_t> makeOffsets(const std::vector<const CaloHitColl*>& colls) {
+    std::vector<size_t> offsets;
+    offsets.reserve(colls.size());
+    size_t acc = 0;
+    for (const auto& c : colls) {
+      offsets.push_back(acc);
+      acc += c->size();
+    }
+    return offsets;
+  }
+
+  // Helper function to resolve global index back to collection and hit index
+  std::pair<size_t, size_t> resolveIndex(const std::vector<size_t>& offsets, size_t globalIndex) {
+    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+    size_t collIdx = std::distance(offsets.begin(), it) - 1;
+    return {collIdx, globalIndex - offsets[collIdx]};
+  };
+} // anonymous namespace
+
 template <uint8_t nDim>
 StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   m_queue = clue::get_queue(0u);
@@ -72,6 +94,15 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
     m_coordinate = Coordinate::Cartesian;
   } else if (m_coordinateName == "Polar") {
     m_coordinate = Coordinate::Polar;
+    // set periodic coordinates for CLUE algo
+    if (nDim==4) {
+      // CLUEstering metric cannot be weighted and periodic at the same time
+      error() << "Polar coordinates not supported for 4D clustering" << endmsg;
+      return StatusCode::FAILURE;
+    }
+    std::vector<uint8_t> coord(nDim, 0);
+    coord[1] = 1; // set phi coordinate as periodic
+    m_clueAlgo->setWrappedCoordinates(coord);
   } else {
     error() << "Unknown coordinate: " << m_coordinateName << endmsg;
     return StatusCode::FAILURE;
@@ -139,15 +170,20 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
     }
   } else if (m_coordinate == Coordinate::Polar) {
     for (size_t i = 0; i < nPoints; ++i) {
-      floatBuffer[i] = clue_hits[i].getTheta();         // Fill theta coordinates
-      floatBuffer[nPoints + i] = clue_hits[i].getPhi(); // Fill phi coordinates
+      float phi = clue_hits[i].getPhi();
+      // Normalize phi to [0, 2*pi] for periodic distance calculation
+      // (clue::PeriodicEuclideanMetric only works with positive periods)
+      if (phi < 0) {
+        phi += 2.0f * M_PI;
+      }
+
+      floatBuffer[i] = clue_hits[i].getTheta(); // Fill theta coordinates
+      floatBuffer[nPoints + i] = phi; // Fill phi coordinates
       if constexpr (nDim >= 3)
         floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
-      if constexpr (nDim >= 4)
-        floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
       floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
     }
-  }
+  } // if Cartesian or Polar (else should not happen due to checks in initialize())
 
   // Construct and return the PointsSoA object
   return clue::PointsHost<nDim>(*m_queue, nPoints, floatBuffer, intBuffer);
@@ -168,12 +204,20 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 
   // measure excution time of make_clusters
   auto start = std::chrono::high_resolution_clock::now();
-  if constexpr (nDim == 4) {
-    auto metric = clue::metrics::WeightedEuclidean<nDim>(1.f, 1.f, 1.f, C_MM_NS_SQUARED);
+  if (m_coordinate==Coordinate::Cartesian) {
+    if constexpr (nDim == 4) {
+      auto metric = clue::metrics::WeightedEuclidean<nDim>(1.f, 1.f, 1.f, C_MM_NS_SQUARED);
+      m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
+    } else {
+      m_clueAlgo->make_clusters(*m_queue, cluePoints);
+    }
+  } else if (m_coordinate==Coordinate::Polar) {
+    std::array<float, nDim> periods{}; // zero-initialize all to non-periodic
+    periods[1] = 2.0f * M_PI; // set phi coordinate as periodic
+    clue::PeriodicEuclideanMetric<nDim> metric(periods);
     m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
-  } else {
-    m_clueAlgo->make_clusters(*m_queue, cluePoints);
-  }
+  } // if Cartesian or Polar (else should not happen due to checks in initialize())
+
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finish - start;
   info() << "ClueGaudiAlgorithmWrapper: Elapsed time: " << elapsed.count() * 1000 << " ms" << endmsg;
@@ -195,7 +239,7 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
       verbose() << " is follower of cluster #" << cluePoints.clusterIndexes()[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::follower);
     }
-  }
+  } // for cluePoints
 
   return clueClusters;
 }
@@ -206,29 +250,12 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
                                                         ClusterColl& clusters,
                                                         const std::vector<const CaloHitColl*>& calo_coll) const {
   // Precompute cumulative offsets once
-  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
-    std::vector<size_t> offsets;
-    offsets.reserve(colls.size());
-    size_t acc = 0;
-    for (const auto& c : colls) {
-      offsets.push_back(acc);
-      acc += c->size();
-    }
-    return offsets;
-  };
-
   const auto collOffsets = makeOffsets(calo_coll);
-
-  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
-    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
-    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
-    size_t collIdx = std::distance(offsets.begin(), it) - 1;
-    return {collIdx, globalIndex - offsets[collIdx]};
-  };
 
   for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
     if (clusterMap.empty(cl)) // check if there are elements associated with index cl
       continue;
+
     auto cluster = clusters.create();
     unsigned int maxEnergyIndex = 0;
     float maxEnergyValue = 0.f;
@@ -240,7 +267,8 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
         maxEnergyValue = clue_hits[index].getEnergy();
         maxEnergyIndex = index;
       }
-    }
+    } // for each hit index in cluster
+
     float energy = 0.f;
     float sumEnergyErrSquared = 0.f;
     std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
@@ -254,7 +282,8 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
     calculatePosition(&cluster);
 
     cluster.setType(clue_hits[maxEnergyIndex].getType());
-  }
+  } // for clusterMap (each cluster)
+
   return;
 }
 
@@ -264,31 +293,14 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
     ClusterColl& clusters, const std::vector<const CaloHitColl*>& calo_coll) const {
   if constexpr (nDim == 2) {
     // Precompute cumulative offsets once
-    auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
-      std::vector<size_t> offsets;
-      offsets.reserve(colls.size());
-      size_t acc = 0;
-      for (const auto& c : colls) {
-        offsets.push_back(acc);
-        acc += c->size();
-      }
-      return offsets;
-    };
-
     const auto collOffsets = makeOffsets(calo_coll);
-
-    auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
-      // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
-      auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
-      size_t collIdx = std::distance(offsets.begin(), it) - 1;
-      return {collIdx, globalIndex - offsets[collIdx]};
-    };
 
     for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
       std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
       for (auto index : clusterMap[cl]) {
         clustersLayer[clue_hits[index].getLayer()].push_back(index);
       }
+
       for (auto clLay : clustersLayer) {
         if (clLay.empty())
           continue;
@@ -303,7 +315,8 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
             maxEnergyValue = clue_hits[index].getEnergy();
             maxEnergyIndex = index;
           }
-        }
+        } // for each hit index in cluster
+
         float energy = 0.f;
         float sumEnergyErrSquared = 0.f;
         std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
@@ -317,11 +330,12 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
         calculatePosition(&cluster);
 
         cluster.setType(clue_hits[maxEnergyIndex].getType());
-      }
-    }
+      } // for each layer
+    } // for clusterMap (each cluster)
   } else {
     fillFinalClusters(clue_hits, clusterMap, clusters, calo_coll);
   }
+
   return;
 }
 
@@ -380,6 +394,7 @@ void ClueGaudiAlgorithmWrapper<nDim>::transformClustersInCaloHits(ClusterColl& c
         maxEnergyCellID = hit.getCellID();
       }
     }
+
     caloHit.setCellID(maxEnergyCellID);
     caloHit.setTime(time / cl.hits_size());
   }
@@ -439,9 +454,9 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       }
       offset += clue_hit_coll_tmp.vect.size();
     }
+
     debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
   } else {
-
     const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
 
     // Get collection metadata cellID which is valid for both EB and EE
@@ -463,7 +478,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
           clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone(),
                                                                     clue::CLUECalorimeterHit::DetectorRegion::barrel,
                                                                     bf.get(calo_hit.getCellID(), "layer")));
-        }
+        } // for each calo_hit in Barrel
       } else if (collName.find("Endcap") != std::string::npos) {
         for (const auto& calo_hit : *coll) {
           if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
@@ -475,7 +490,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
                 clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
                                          bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
           }
-        }
+        } // for each calo_hit in Endcap
       } else
         throw std::runtime_error("With 'PerDetectorRegion' strategy the collection must be Barrel or Endcap");
 
@@ -492,32 +507,39 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       } else {
         info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
       }
+
       offset += clue_hit_coll_tmp.vect.size();
-    }
+    } // for each collection
     debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
-  }
+  } // if-else on strategy
 
-  // Save CLUE calo hits
-  auto pCHV = std::make_unique<clue::CLUECalorimeterHitCollection>(clue_hit_coll);
-  const StatusCode scStatusV = eventSvc()->registerObject("/Event/" + m_CLUECaloHitCollName, pCHV.release());
-  if (scStatusV.isFailure()) {
-    throw std::runtime_error("Failed to register " + m_CLUECaloHitCollName);
-  }
-  debug() << "Saved " << clue_hit_coll.vect.size() << " CLUE calo hits in total. " << endmsg;
-
-  // Save clusters as calo hits and add cellID to them
+  // if configured, save clusters as calo hits as well, in addition to regular clusters
   auto finalCaloHits = CaloHitColl();
-  transformClustersInCaloHits(finalClusters, finalCaloHits);
-  debug() << "Saved " << finalCaloHits.size() << " clusters as calo hits" << endmsg;
 
-  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
-  // Get collection metadata cellID which is valid for both EB and EE
-  const std::string cellIDstr =
-      k4FWCore::getParameter<std::string>(
-          podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding), this)
-          .value_or("");
-  for (auto i = 0u; i < outputLocationsSize(); ++i)
-    k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);
+  if (m_saveClustersAsHits) {
+    debug() << "Saving clusters as calo hits as well, in addition to regular clusters" << endmsg;
+
+    // Save CLUE calo hits
+    auto pCHV = std::make_unique<clue::CLUECalorimeterHitCollection>(clue_hit_coll);
+    const StatusCode scStatusV = eventSvc()->registerObject("/Event/" + m_CLUECaloHitCollName, pCHV.release());
+    if (scStatusV.isFailure())
+      throw std::runtime_error("Failed to register " + m_CLUECaloHitCollName);
+
+    debug() << "Saved " << clue_hit_coll.vect.size() << " CLUE calo hits in total. " << endmsg;
+
+    // Save clusters as calo hits and add cellID to them
+    transformClustersInCaloHits(finalClusters, finalCaloHits);
+    debug() << "Saved " << finalCaloHits.size() << " clusters as calo hits" << endmsg;
+
+    // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
+    // Get collection metadata cellID which is valid for both EB and EE
+    const std::string cellIDstr =
+        k4FWCore::getParameter<std::string>(
+            podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding), this)
+            .value_or("");
+    for (auto i = 0u; i < outputLocationsSize(); ++i)
+      k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);
+  } // if m_saveClustersAsHits
 
   // Cleaning
   clue_hit_coll.vect.clear();

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -163,8 +163,8 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
   auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data());
 
   // Run CLUE
-  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << (uint16_t)nDim << "D"
-          << endmsg;
+  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << (uint16_t)nDim
+          << "D" << endmsg;
 
   // measure excution time of make_clusters
   auto start = std::chrono::high_resolution_clock::now();
@@ -422,7 +422,8 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       for (const auto& calo_hit : *coll) {
         clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
       }
-      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits in collection " << ClusterCollectionsNames[collIndex] << "." << endmsg;
+      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits in collection "
+             << ClusterCollectionsNames[collIndex] << "." << endmsg;
       collIndex++;
 
       if (!clue_hit_coll_tmp.vect.empty()) {
@@ -466,17 +467,16 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       } else if (collName.find("Endcap") != std::string::npos) {
         for (const auto& calo_hit : *coll) {
           if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
-            clue_hit_coll_tmp.vect.push_back(
-                clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
-                                         bf.get(calo_hit.getCellID(), "layer")));
+            clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone(),
+                                                                      clue::CLUECalorimeterHit::DetectorRegion::endcap,
+                                                                      bf.get(calo_hit.getCellID(), "layer")));
           } else {
             clue_hit_coll_tmp.vect.push_back(
                 clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
                                          bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
           }
         }
-      }
-      else
+      } else
         throw std::runtime_error("With 'PerDetectorRegion' strategy the collection must be Barrel or Endcap");
 
       info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits " << collName << "." << endmsg;

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -110,25 +110,29 @@ void ClueGaudiAlgorithmWrapper<nDim>::printTimingReport(std::vector<float>& vals
 template <uint8_t nDim>
 clue::PointsHost<nDim>
 ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalorimeterHit>& clue_hits,
-                                                float* floatBuffer, int* intBuffer, const bool /*isBarrel*/) const {
+                                                float* floatBuffer, int* intBuffer, const bool cartesian) const {
   size_t nPoints = clue_hits.size();
 
-  for (size_t i = 0; i < nPoints; ++i) {
-    // if (isBarrel) {
-    //   floatBuffer[i] = clue_hits[i].getPhi();                  // Fill phi coordinates
-    //   floatBuffer[nPoints + i] = clue_hits[i].getPosition().z; // Fill z coordinates
-    //   if constexpr (nDim == 3)
-    //     floatBuffer[nPoints * 2 + i] = clue_hits[i].getEta();     // Fill eta coordinates
-    //   floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
-    // } else {
-    floatBuffer[i] = clue_hits[i].getPosition().x;           // Fill x coordinates
-    floatBuffer[nPoints + i] = clue_hits[i].getPosition().y; // Fill y coordinates
-    if constexpr (nDim >= 3)
-      floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
-    if constexpr (nDim >= 4)
-      floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
-    floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
-    //}
+  if (cartesian) {
+    for (size_t i = 0; i < nPoints; ++i) {
+      floatBuffer[i] = clue_hits[i].getPosition().x;           // Fill x coordinates
+      floatBuffer[nPoints + i] = clue_hits[i].getPosition().y; // Fill y coordinates
+      if constexpr (nDim >= 3)
+        floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
+      if constexpr (nDim >= 4)
+        floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
+      floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
+    }
+  } else {
+    for (size_t i = 0; i < nPoints; ++i) {
+      floatBuffer[i] = clue_hits[i].getEta();             // Fill eta coordinates
+      floatBuffer[nPoints + i] = clue_hits[i].getPhi();   // Fill phi coordinates
+      if constexpr (nDim >= 3)
+        floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
+      if constexpr (nDim >= 4)
+        floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
+      floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
+    }
   }
 
   // Construct and return the PointsSoA object
@@ -136,13 +140,12 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
 }
 
 template <uint8_t nDim>
-clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits,
-                                                                  const bool isBarrel, const uint32_t offset) const {
+clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const uint32_t offset, const bool cartesian) const {
   // Fill CLUE inputs
   size_t nPoints = clue_hits.size();
   std::vector<float> floatBuffer(nPoints * (nDim + 1));
   std::vector<int> intBuffer(nPoints * 2);
-  auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data(), isBarrel);
+  auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data(), cartesian);
 
   // Run CLUE
   debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << nDim << "D" << endmsg;

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -68,6 +68,15 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
     return StatusCode::FAILURE;
   }
 
+  if (m_coordinateName == "Cartesian") {
+    m_coordinate = Coordinate::Cartesian;
+  } else if (m_coordinateName == "Polar") {
+    m_coordinate = Coordinate::Polar;
+  } else {
+    error() << "Unknown coordinate: " << m_coordinateName << endmsg;
+    return StatusCode::FAILURE;
+  }
+
   return Algorithm::initialize();
 }
 
@@ -115,10 +124,10 @@ void ClueGaudiAlgorithmWrapper<nDim>::printTimingReport(std::vector<float>& vals
 template <uint8_t nDim>
 clue::PointsHost<nDim>
 ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalorimeterHit>& clue_hits,
-                                                float* floatBuffer, int* intBuffer, const bool cartesian) const {
+                                                float* floatBuffer, int* intBuffer) const {
   size_t nPoints = clue_hits.size();
 
-  if (cartesian) {
+  if (m_coordinate == Coordinate::Cartesian) {
     for (size_t i = 0; i < nPoints; ++i) {
       floatBuffer[i] = clue_hits[i].getPosition().x;           // Fill x coordinates
       floatBuffer[nPoints + i] = clue_hits[i].getPosition().y; // Fill y coordinates
@@ -128,10 +137,10 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
         floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
       floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
     }
-  } else {
+  } else if (m_coordinate == Coordinate::Polar) {
     for (size_t i = 0; i < nPoints; ++i) {
-      floatBuffer[i] = clue_hits[i].getTheta();             // Fill eta coordinates
-      floatBuffer[nPoints + i] = clue_hits[i].getPhi();   // Fill phi coordinates
+      floatBuffer[i] = clue_hits[i].getTheta();         // Fill eta coordinates
+      floatBuffer[nPoints + i] = clue_hits[i].getPhi(); // Fill phi coordinates
       if constexpr (nDim >= 3)
         floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
       if constexpr (nDim >= 4)
@@ -145,19 +154,21 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
 }
 
 template <uint8_t nDim>
-clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const uint32_t offset, const bool cartesian) const {
+clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits,
+                                                                  const uint32_t offset) const {
   // Fill CLUE inputs
   size_t nPoints = clue_hits.size();
   std::vector<float> floatBuffer(nPoints * (nDim + 1));
   std::vector<int> intBuffer(nPoints * 2);
-  auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data(), cartesian);
+  auto cluePoints = fillCLUEPoints(clue_hits, floatBuffer.data(), intBuffer.data());
 
   // Run CLUE
-  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << nDim << "D" << endmsg;
+  debug() << "Running CLUEAlgo on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " in " << (uint16_t)nDim << "D"
+          << endmsg;
 
   // measure excution time of make_clusters
   auto start = std::chrono::high_resolution_clock::now();
-  if constexpr(nDim==4) {
+  if constexpr (nDim == 4) {
     auto metric = clue::metrics::WeightedEuclidean<nDim>(1.f, 1.f, 1.f, C_MM_NS_SQUARED);
     m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
   } else {

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -124,8 +124,8 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
     if constexpr (nDim >= 3)
       floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
     if constexpr (nDim >= 4)
-      floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime(); // Fill time coordinates
-    floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy();    // Fill weights
+      floatBuffer[nPoints * 3 + i] = clue_hits[i].getTime();    // Fill time coordinates
+    floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
     //}
   }
 
@@ -177,8 +177,31 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                                                         clue::AssociationMapHost const& clusterMap,
-                                                        ClusterColl& clusters, const CaloHitColl& EB_calo_coll,
-                                                        const CaloHitColl& EE_calo_coll) const {
+                                                        ClusterColl& clusters,
+                                                        const std::vector<const CaloHitColl*>& EB_calo_coll,
+                                                        const std::vector<const CaloHitColl*>& EE_calo_coll) const {
+  // Precompute cumulative offsets once
+  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
+    std::vector<size_t> offsets;
+    offsets.reserve(colls.size());
+    size_t acc = 0;
+    for (const auto& c : colls) {
+      offsets.push_back(acc);
+      acc += c->size();
+    }
+    return offsets;
+  };
+
+  const auto ebOffsets = makeOffsets(EB_calo_coll);
+  const auto eeOffsets = makeOffsets(EE_calo_coll);
+
+  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
+    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+    size_t collIdx = std::distance(offsets.begin(), it) - 1;
+    return {collIdx, globalIndex - offsets[collIdx]};
+  };
+
   for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
     if (clusterMap.empty(cl))
       continue;
@@ -187,10 +210,12 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
     float maxEnergyValue = 0.f;
     for (auto index : clusterMap[cl]) {
       if (clue_hits[index].inBarrel()) {
-        cluster.addToHits(EB_calo_coll.at(index));
+        auto [collIdx, localIdx] = resolveIndex(ebOffsets, index);
+        cluster.addToHits(EB_calo_coll[collIdx]->at(localIdx));
       }
       if (clue_hits[index].inEndcap()) {
-        cluster.addToHits(EE_calo_coll.at(index));
+        auto [collIdx, localIdx] = resolveIndex(eeOffsets, index);
+        cluster.addToHits(EE_calo_coll[collIdx]->at(localIdx));
       }
 
       if (clue_hits[index].getEnergy() > maxEnergyValue) {
@@ -218,8 +243,30 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
 template <>
 void ClueGaudiAlgorithmWrapper<2>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                                                      clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-                                                     const CaloHitColl& EB_calo_coll,
-                                                     const CaloHitColl& EE_calo_coll) const {
+                                                     const std::vector<const CaloHitColl*>& EB_calo_coll,
+                                                     const std::vector<const CaloHitColl*>& EE_calo_coll) const {
+  // Precompute cumulative offsets once
+  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
+    std::vector<size_t> offsets;
+    offsets.reserve(colls.size());
+    size_t acc = 0;
+    for (const auto& c : colls) {
+      offsets.push_back(acc);
+      acc += c->size();
+    }
+    return offsets;
+  };
+
+  const auto ebOffsets = makeOffsets(EB_calo_coll);
+  const auto eeOffsets = makeOffsets(EE_calo_coll);
+
+  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
+    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+    size_t collIdx = std::distance(offsets.begin(), it) - 1;
+    return {collIdx, globalIndex - offsets[collIdx]};
+  };
+
   for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
     std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
     for (auto index : clusterMap[cl]) {
@@ -233,10 +280,12 @@ void ClueGaudiAlgorithmWrapper<2>::fillFinalClusters(std::vector<clue::CLUECalor
       float maxEnergyValue = 0.f;
       for (auto index : clusterMap[cl]) {
         if (clue_hits[index].inBarrel()) {
-          cluster.addToHits(EB_calo_coll.at(index));
+          auto [collIdx, localIdx] = resolveIndex(ebOffsets, index);
+          cluster.addToHits(EB_calo_coll[collIdx]->at(localIdx));
         }
         if (clue_hits[index].inEndcap()) {
-          cluster.addToHits(EE_calo_coll.at(index));
+          auto [collIdx, localIdx] = resolveIndex(eeOffsets, index);
+          cluster.addToHits(EE_calo_coll[collIdx]->at(localIdx));
         }
 
         if (clue_hits[index].getEnergy() > maxEnergyValue) {
@@ -325,8 +374,8 @@ void ClueGaudiAlgorithmWrapper<nDim>::transformClustersInCaloHits(ClusterColl& c
 }
 
 template <uint8_t nDim>
-retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_coll,
-                                                    const CaloHitColl& EE_calo_coll) const {
+retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const CaloHitColl*>& EB_calo_coll,
+                                                    const std::vector<const CaloHitColl*>& EE_calo_coll) const {
 
   // Get collection metadata cellID which is valid for both EB and EE
   const std::string cellIDstr =
@@ -341,18 +390,17 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_c
   clue::CLUECalorimeterHitCollection clue_hit_coll_barrel;
   clue::CLUECalorimeterHitCollection clue_hit_coll_endcap;
 
-  info() << "ClueGaudiAlgorithmWrapper: Total number of calo hits: " << int(EB_calo_coll.size() + EE_calo_coll.size())
-         << " (" << EB_calo_coll.size() << " in the barrel and " << EE_calo_coll.size() << " in the endcap)" << endmsg;
-  debug() << "Processing " << EB_calo_coll.size() << " caloHits in the barrel." << endmsg;
-
   // Fill CLUECaloHits in the barrel
-  for (const auto& calo_hit : EB_calo_coll) {
-    // Cut on a specific layer for noise studies
-    // if(bf.get( calo_hit.getCellID(), "layer") == 6){
-    clue_hit_coll_barrel.vect.push_back(clue::CLUECalorimeterHit(
-        calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::barrel, bf.get(calo_hit.getCellID(), "layer")));
-    //}
+  for (const auto& coll : EB_calo_coll) {
+    for (const auto& calo_hit : *coll) {
+      // Cut on a specific layer for noise studies
+      // if(bf.get( calo_hit.getCellID(), "layer") == 6){
+      clue_hit_coll_barrel.vect.push_back(clue::CLUECalorimeterHit(
+          calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::barrel, bf.get(calo_hit.getCellID(), "layer")));
+      //}
+    }
   }
+  info() << "Processing " << clue_hit_coll_barrel.vect.size() << " caloHits in the barrel." << endmsg;
 
   // Run CLUE in the barrel
   if (!clue_hit_coll_barrel.vect.empty()) {
@@ -367,19 +415,20 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const CaloHitColl& EB_calo_c
   }
   uint32_t barrelOffset = finalClusters.size();
 
-  debug() << "Processing " << EE_calo_coll.size() << " caloHits in the endcap." << endmsg;
-
   // Fill CLUECaloHits in the endcap
-  for (const auto& calo_hit : EE_calo_coll) {
-    if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
-      clue_hit_coll_endcap.vect.push_back(clue::CLUECalorimeterHit(
-          calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap, bf.get(calo_hit.getCellID(), "layer")));
-    } else {
-      clue_hit_coll_endcap.vect.push_back(
-          clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
-                                   bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
+  for (const auto& coll : EE_calo_coll) {
+    for (const auto& calo_hit : *coll) {
+      if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
+        clue_hit_coll_endcap.vect.push_back(clue::CLUECalorimeterHit(
+            calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap, bf.get(calo_hit.getCellID(), "layer")));
+      } else {
+        clue_hit_coll_endcap.vect.push_back(
+            clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
+                                     bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
+      }
     }
   }
+  info() << "Processing " << clue_hit_coll_endcap.vect.size() << " caloHits in the endcap." << endmsg;
 
   // Run CLUE in the endcap
   if (!clue_hit_coll_endcap.vect.empty()) {

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -45,25 +45,25 @@ DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<2>, "ClueGaudiAlgorithmWrapp
 #endif
 
 namespace {
-  // Helper function to compute offsets for merged collections
-  std::vector<size_t> makeOffsets(const std::vector<const CaloHitColl*>& colls) {
-    std::vector<size_t> offsets;
-    offsets.reserve(colls.size());
-    size_t acc = 0;
-    for (const auto& c : colls) {
-      offsets.push_back(acc);
-      acc += c->size();
-    }
-    return offsets;
+// Helper function to compute offsets for merged collections
+std::vector<size_t> makeOffsets(const std::vector<const CaloHitColl*>& colls) {
+  std::vector<size_t> offsets;
+  offsets.reserve(colls.size());
+  size_t acc = 0;
+  for (const auto& c : colls) {
+    offsets.push_back(acc);
+    acc += c->size();
   }
+  return offsets;
+}
 
-  // Helper function to resolve global index back to collection and hit index
-  std::pair<size_t, size_t> resolveIndex(const std::vector<size_t>& offsets, size_t globalIndex) {
-    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
-    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
-    size_t collIdx = std::distance(offsets.begin(), it) - 1;
-    return {collIdx, globalIndex - offsets[collIdx]};
-  };
+// Helper function to resolve global index back to collection and hit index
+std::pair<size_t, size_t> resolveIndex(const std::vector<size_t>& offsets, size_t globalIndex) {
+  // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+  auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+  size_t collIdx = std::distance(offsets.begin(), it) - 1;
+  return {collIdx, globalIndex - offsets[collIdx]};
+};
 } // anonymous namespace
 
 template <uint8_t nDim>
@@ -71,13 +71,15 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   m_queue = clue::get_queue(0u);
 
   const auto seeding_distance = (m_seed_dc == -1.f) ? m_dc : m_seed_dc;
+  const auto outlier_distance = (m_dm == -1.f) ? m_dc : m_dm;
   auto start = std::chrono::high_resolution_clock::now();
-  m_clueAlgo =
-      std::make_optional<clue::Clusterer<nDim>>(*m_queue, m_dc, m_rhoc, m_dm, seeding_distance, m_pointsPerBin);
+  m_clueAlgo = std::make_optional<clue::Clusterer<nDim>>(*m_queue, m_dc, m_rhoc, outlier_distance, seeding_distance,
+                                                         m_pointsPerBin);
   auto finish = std::chrono::high_resolution_clock::now();
   std::chrono::duration<double> elapsed = finish - start;
   debug() << "ClueGaudiAlgorithmWrapper: Set up time: " << elapsed.count() * 1000 << " ms" << endmsg;
-  info() << "CLUEAlgo will run on device " << alpaka::getName(alpaka::getDev(*m_queue)) << endmsg;
+  info() << "CLUEAlgo will run on device " << alpaka::getName(alpaka::getDev(*m_queue)) << " and params " << m_dc
+         << ", " << m_rhoc << ", " << outlier_distance << ", " << seeding_distance << endmsg;
 
   if (m_strategyName == "PerDetectorRegion") {
     m_strategy = Strategy::PerDetectorRegion;
@@ -95,9 +97,9 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
   } else if (m_coordinateName == "Polar") {
     m_coordinate = Coordinate::Polar;
     // set periodic coordinates for CLUE algo
-    if (nDim==4) {
-      // CLUEstering metric cannot be weighted and periodic at the same time
-      error() << "Polar coordinates not supported for 4D clustering" << endmsg;
+    if (nDim == 4) {
+      // TODO: Implement custom metric weighted and periodic at the same time
+      error() << "Polar coordinates not yet supported for 4D clustering" << endmsg;
       return StatusCode::FAILURE;
     }
     std::vector<uint8_t> coord(nDim, 0);
@@ -178,10 +180,10 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
       }
 
       floatBuffer[i] = clue_hits[i].getTheta(); // Fill theta coordinates
-      floatBuffer[nPoints + i] = phi; // Fill phi coordinates
+      floatBuffer[nPoints + i] = phi;           // Fill phi coordinates
       if constexpr (nDim >= 3)
         floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates
-      floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy(); // Fill weights
+      floatBuffer[nPoints * nDim + i] = clue_hits[i].getEnergy();    // Fill weights
     }
   } // if Cartesian or Polar (else should not happen due to checks in initialize())
 
@@ -204,16 +206,16 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 
   // measure excution time of make_clusters
   auto start = std::chrono::high_resolution_clock::now();
-  if (m_coordinate==Coordinate::Cartesian) {
+  if (m_coordinate == Coordinate::Cartesian) {
     if constexpr (nDim == 4) {
       auto metric = clue::metrics::WeightedEuclidean<nDim>(1.f, 1.f, 1.f, C_MM_NS_SQUARED);
       m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
     } else {
       m_clueAlgo->make_clusters(*m_queue, cluePoints);
     }
-  } else if (m_coordinate==Coordinate::Polar) {
+  } else if (m_coordinate == Coordinate::Polar) {
     std::array<float, nDim> periods{}; // zero-initialize all to non-periodic
-    periods[1] = 2.0f * M_PI; // set phi coordinate as periodic
+    periods[1] = 2.0f * M_PI;          // set phi coordinate as periodic
     clue::PeriodicEuclideanMetric<nDim> metric(periods);
     m_clueAlgo->make_clusters(*m_queue, cluePoints, metric);
   } // if Cartesian or Polar (else should not happen due to checks in initialize())
@@ -259,23 +261,20 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
     auto cluster = clusters.create();
     unsigned int maxEnergyIndex = 0;
     float maxEnergyValue = 0.f;
+    float energy = 0.f;
+    float sumEnergyErrSquared = 0.f;
     for (auto index : clusterMap[cl]) {
       auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
       cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
-      if (clue_hits[index].getEnergy() > maxEnergyValue) {
-        maxEnergyValue = clue_hits[index].getEnergy();
+      float hitEne = clue_hits[index].getEnergy();
+      if (hitEne > maxEnergyValue) {
+        maxEnergyValue = hitEne;
         maxEnergyIndex = index;
       }
-    } // for each hit index in cluster
-
-    float energy = 0.f;
-    float sumEnergyErrSquared = 0.f;
-    std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
-                  [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
-                    energy += elem.getEnergy();
-                    sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
-                  });
+      energy += hitEne;
+      sumEnergyErrSquared += pow(clue_hits[index].getEnergyError() / (1.f * hitEne), 2);
+    }
     cluster.setEnergy(energy);
     cluster.setEnergyError(std::sqrt(sumEnergyErrSquared));
 
@@ -307,23 +306,20 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
         auto cluster = clusters.create();
         unsigned int maxEnergyIndex = 0;
         float maxEnergyValue = 0.f;
+        float energy = 0.f;
+        float sumEnergyErrSquared = 0.f;
         for (auto index : clusterMap[cl]) {
           auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
           cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
-          if (clue_hits[index].getEnergy() > maxEnergyValue) {
-            maxEnergyValue = clue_hits[index].getEnergy();
+          float hitEne = clue_hits[index].getEnergy();
+          if (hitEne > maxEnergyValue) {
+            maxEnergyValue = hitEne;
             maxEnergyIndex = index;
           }
-        } // for each hit index in cluster
-
-        float energy = 0.f;
-        float sumEnergyErrSquared = 0.f;
-        std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
-                      [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
-                        energy += elem.getEnergy();
-                        sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
-                      });
+          energy += hitEne;
+          sumEnergyErrSquared += pow(clue_hits[index].getEnergyError() / (1.f * hitEne), 2);
+        }
         cluster.setEnergy(energy);
         cluster.setEnergyError(sqrt(sumEnergyErrSquared));
 
@@ -535,7 +531,8 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
     // Get collection metadata cellID which is valid for both EB and EE
     const std::string cellIDstr =
         k4FWCore::getParameter<std::string>(
-            podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding), this)
+            podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding),
+            this)
             .value_or("");
     for (auto i = 0u; i < outputLocationsSize(); ++i)
       k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -110,6 +110,13 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
     return StatusCode::FAILURE;
   }
 
+  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
+  // Get collection metadata cellID which is valid for both EB and EE
+  const std::string cellIDstr =
+      k4FWCore::getCellIDEncoding(inputLocations("CaloHitsCollections")[0], this).value_or("");
+  for (auto i = 0u; i < outputLocationsSize(); ++i)
+    k4FWCore::putCellIDEncoding(outputLocations(i)[0], cellIDstr, this);
+
   return Algorithm::initialize();
 }
 
@@ -527,15 +534,6 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
     transformClustersInCaloHits(finalClusters, finalCaloHits);
     debug() << "Saved " << finalCaloHits.size() << " clusters as calo hits" << endmsg;
 
-    // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
-    // Get collection metadata cellID which is valid for both EB and EE
-    const std::string cellIDstr =
-        k4FWCore::getParameter<std::string>(
-            podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding),
-            this)
-            .value_or("");
-    for (auto i = 0u; i < outputLocationsSize(); ++i)
-      k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);
   } // if m_saveClustersAsHits
 
   // Cleaning

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -125,7 +125,7 @@ ClueGaudiAlgorithmWrapper<nDim>::fillCLUEPoints(const std::vector<clue::CLUECalo
     }
   } else {
     for (size_t i = 0; i < nPoints; ++i) {
-      floatBuffer[i] = clue_hits[i].getEta();             // Fill eta coordinates
+      floatBuffer[i] = clue_hits[i].getTheta();             // Fill eta coordinates
       floatBuffer[nPoints + i] = clue_hits[i].getPhi();   // Fill phi coordinates
       if constexpr (nDim >= 3)
         floatBuffer[nPoints * 2 + i] = clue_hits[i].getPosition().z; // Fill z coordinates

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -28,7 +28,7 @@
 using namespace dd4hep;
 using namespace DDSegmentation;
 
-constexpr float C_MM_NS_SQUARED = 299.792458f*299.792458f;
+constexpr float C_MM_NS_SQUARED = 299.792458f * 299.792458f;
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 DECLARE_COMPONENT_WITH_ID(ClueGaudiAlgorithmWrapper<4>, "ClueGaudiAlgorithmWrapperCUDA4D")
@@ -222,8 +222,8 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
     unsigned int maxEnergyIndex = 0;
     float maxEnergyValue = 0.f;
     for (auto index : clusterMap[cl]) {
-        auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
-        cluster.addToHits(calo_coll[collIdx]->at(localIdx));
+      auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
+      cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
       if (clue_hits[index].getEnergy() > maxEnergyValue) {
         maxEnergyValue = clue_hits[index].getEnergy();
@@ -247,68 +247,72 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
   return;
 }
 
-//template <>
-//void ClueGaudiAlgorithmWrapper<2>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
-//                                                     clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-//                                                     const std::vector<const CaloHitColl*>& calo_coll) const {
-//  // Precompute cumulative offsets once
-//  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
-//    std::vector<size_t> offsets;
-//    offsets.reserve(colls.size());
-//    size_t acc = 0;
-//    for (const auto& c : colls) {
-//      offsets.push_back(acc);
-//      acc += c->size();
-//    }
-//    return offsets;
-//  };
-//
-//  const auto offsets = makeOffsets(calo_coll);
-//
-//  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
-//    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
-//    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
-//    size_t collIdx = std::distance(offsets.begin(), it) - 1;
-//    return {collIdx, globalIndex - offsets[collIdx]};
-//  };
-//
-//  for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
-//    std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
-//    for (auto index : clusterMap[cl]) {
-//      clustersLayer[clue_hits[index].getLayer()].push_back(index);
-//    }
-//    for (auto clLay : clustersLayer) {
-//      if (clLay.empty())
-//        continue;
-//      auto cluster = clusters.create();
-//      unsigned int maxEnergyIndex = 0;
-//      float maxEnergyValue = 0.f;
-//      for (auto index : clusterMap[cl]) {
-//        auto [collIdx, localIdx] = resolveIndex(offsets, index);
-//        cluster.addToHits(calo_coll[collIdx]->at(localIdx));
-//
-//        if (clue_hits[index].getEnergy() > maxEnergyValue) {
-//          maxEnergyValue = clue_hits[index].getEnergy();
-//          maxEnergyIndex = index;
-//        }
-//      }
-//      float energy = 0.f;
-//      float sumEnergyErrSquared = 0.f;
-//      std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
-//                    [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
-//                      energy += elem.getEnergy();
-//                      sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
-//                    });
-//      cluster.setEnergy(energy);
-//      cluster.setEnergyError(sqrt(sumEnergyErrSquared));
-//
-//      calculatePosition(&cluster);
-//
-//      cluster.setType(clue_hits[maxEnergyIndex].getType());
-//    }
-//  }
-//  return;
-//}
+template <uint8_t nDim>
+void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
+    std::vector<clue::CLUECalorimeterHit> const& clue_hits, clue::AssociationMapHost const& clusterMap,
+    ClusterColl& clusters, const std::vector<const CaloHitColl*>& calo_coll) const {
+  if constexpr (nDim == 2) {
+    // Precompute cumulative offsets once
+    auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
+      std::vector<size_t> offsets;
+      offsets.reserve(colls.size());
+      size_t acc = 0;
+      for (const auto& c : colls) {
+        offsets.push_back(acc);
+        acc += c->size();
+      }
+      return offsets;
+    };
+
+    const auto collOffsets = makeOffsets(calo_coll);
+
+    auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
+      // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+      auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+      size_t collIdx = std::distance(offsets.begin(), it) - 1;
+      return {collIdx, globalIndex - offsets[collIdx]};
+    };
+
+    for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
+      std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
+      for (auto index : clusterMap[cl]) {
+        clustersLayer[clue_hits[index].getLayer()].push_back(index);
+      }
+      for (auto clLay : clustersLayer) {
+        if (clLay.empty())
+          continue;
+        auto cluster = clusters.create();
+        unsigned int maxEnergyIndex = 0;
+        float maxEnergyValue = 0.f;
+        for (auto index : clusterMap[cl]) {
+          auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
+          cluster.addToHits(calo_coll[collIdx]->at(localIdx));
+
+          if (clue_hits[index].getEnergy() > maxEnergyValue) {
+            maxEnergyValue = clue_hits[index].getEnergy();
+            maxEnergyIndex = index;
+          }
+        }
+        float energy = 0.f;
+        float sumEnergyErrSquared = 0.f;
+        std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
+                      [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
+                        energy += elem.getEnergy();
+                        sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
+                      });
+        cluster.setEnergy(energy);
+        cluster.setEnergyError(sqrt(sumEnergyErrSquared));
+
+        calculatePosition(&cluster);
+
+        cluster.setType(clue_hits[maxEnergyIndex].getType());
+      }
+    }
+  } else {
+    fillFinalClusters(clue_hits, clusterMap, clusters, calo_coll);
+  }
+  return;
+}
 
 template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::calculatePosition(edm4hep::MutableCluster* cluster) const {
@@ -387,92 +391,100 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
         clue_hit_coll.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
       }
     }
-    info() << "Processing " << clue_hit_coll.vect.size() << " caloHits." << endmsg;
+    info() << "Processing " << clue_hit_coll.vect.size() << " caloHits in one pass." << endmsg;
 
     if (!clue_hit_coll.vect.empty()) {
       auto clueClusters = runAlgo(clue_hit_coll.vect);
       info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
 
       fillFinalClusters(clue_hit_coll.vect, clueClusters, finalClusters, calo_coll);
-      debug() << "Saved " << finalClusters.size() << " clusters" << endmsg;
+      debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
     } else {
       info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
     }
   } else if (m_strategy == Strategy::PerCollection) {
     int offset = 0;
+    int collIndex = 0;
+    const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
     for (const auto& coll : calo_coll) {
       clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
       for (const auto& calo_hit : *coll) {
         clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
       }
-      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits." << endmsg;
+      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits in collection " << ClusterCollectionsNames[collIndex] << "." << endmsg;
+      collIndex++;
 
       if (!clue_hit_coll_tmp.vect.empty()) {
         auto clueClusters = runAlgo(clue_hit_coll_tmp.vect, offset);
         info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
 
         fillFinalClusters(clue_hit_coll_tmp.vect, clueClusters, finalClusters, calo_coll);
-        debug() << "Saved " << finalClusters.size() - offset << " clusters" << endmsg;
 
         clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_tmp.vect.begin(),
-                              clue_hit_coll_tmp.vect.end());
+                                  clue_hit_coll_tmp.vect.end());
       } else {
         info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
       }
       offset += clue_hit_coll_tmp.vect.size();
     }
+    debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
   } else {
 
-  const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
-  for (auto s : ClusterCollectionsNames)
-    std::cout <<  s << std::endl;
-  // keep layers here AND LOOK for barrel/endcap in collection name
+    const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
+
+    // Get collection metadata cellID which is valid for both EB and EE
+    const std::string cellIDstr =
+        k4FWCore::getParameter<std::string>(
+            podio::collMetadataParamName(ClusterCollectionsNames[0], edm4hep::labels::CellIDEncoding), this)
+            .value_or("");
+    const BitFieldCoder bf(cellIDstr);
+
+    // Fill CLUECaloHits per region
+    int offset = 0;
+    int collIndex = 0;
+    for (const auto& coll : calo_coll) {
+      clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
+      std::string const& collName = ClusterCollectionsNames[collIndex];
+      collIndex++;
+      if (collName.find("Barrel") != std::string::npos) {
+        for (const auto& calo_hit : *coll) {
+          clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone(),
+                                                                    clue::CLUECalorimeterHit::DetectorRegion::barrel,
+                                                                    bf.get(calo_hit.getCellID(), "layer")));
+        }
+      } else if (collName.find("Endcap") != std::string::npos) {
+        for (const auto& calo_hit : *coll) {
+          if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
+            clue_hit_coll_tmp.vect.push_back(
+                clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
+                                         bf.get(calo_hit.getCellID(), "layer")));
+          } else {
+            clue_hit_coll_tmp.vect.push_back(
+                clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
+                                         bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
+          }
+        }
+      }
+      else
+        throw std::runtime_error("With 'PerDetectorRegion' strategy the collection must be Barrel or Endcap");
+
+      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits " << collName << "." << endmsg;
+
+      if (!clue_hit_coll_tmp.vect.empty()) {
+        auto clueClusters = runAlgo(clue_hit_coll_tmp.vect, offset);
+        info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
+
+        fillFinalClustersPerLayer(clue_hit_coll_tmp.vect, clueClusters, finalClusters, calo_coll);
+
+        clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_tmp.vect.begin(),
+                                  clue_hit_coll_tmp.vect.end());
+      } else {
+        info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
+      }
+      offset += clue_hit_coll_tmp.vect.size();
+    }
+    debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
   }
-
-  // Get collection metadata cellID which is valid for both EB and EE
-  //const std::string cellIDstr =
-  //    k4FWCore::getParameter<std::string>(
-  //        podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
-  //        .value_or("");
-  //const BitFieldCoder bf(cellIDstr);
-
-  //// Fill CLUECaloHits in the barrel
-  //for (const auto& coll : EB_calo_coll) {
-  //  for (const auto& calo_hit : *coll) {
-  //    clue_hit_coll_barrel.vect.push_back(clue::CLUECalorimeterHit(
-  //        calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::barrel, bf.get(calo_hit.getCellID(), "layer")));
-  //  }
-  //}
-  //uint32_t barrelOffset = finalClusters.size();
-
-  //// Fill CLUECaloHits in the endcap
-  //for (const auto& coll : EE_calo_coll) {
-  //  for (const auto& calo_hit : *coll) {
-  //    if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
-  //      clue_hit_coll_endcap.vect.push_back(clue::CLUECalorimeterHit(
-  //          calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap, bf.get(calo_hit.getCellID(), "layer")));
-  //    } else {
-  //      clue_hit_coll_endcap.vect.push_back(
-  //          clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
-  //                                   bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
-  //    }
-  //  }
-  //}
-  //info() << "Processing " << clue_hit_coll_endcap.vect.size() << " caloHits in the endcap." << endmsg;
-
-  //// Run CLUE in the endcap
-  //if (!clue_hit_coll_endcap.vect.empty()) {
-  //  auto clueClustersEndcap = runAlgo(clue_hit_coll_endcap.vect, false, barrelOffset);
-  //  info() << "Produced " << clueClustersEndcap.size() << " clusters in the endcap" << endmsg;
-
-  //  clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_endcap.vect.begin(),
-  //                            clue_hit_coll_endcap.vect.end());
-
-  //  fillFinalClusters(clue_hit_coll_endcap.vect, clueClustersEndcap, finalClusters, EB_calo_coll, EE_calo_coll);
-  //  debug() << "Saved " << finalClusters.size() - barrelOffset << " clusters using endcap hits" << endmsg;
-  //}
-
-  //info() << "Saved " << finalClusters.size() << " CLUE clusters in total." << endmsg;
 
   // Save CLUE calo hits
   auto pCHV = std::make_unique<clue::CLUECalorimeterHitCollection>(clue_hit_coll);
@@ -491,7 +503,7 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
   // Get collection metadata cellID which is valid for both EB and EE
   const std::string cellIDstr =
       k4FWCore::getParameter<std::string>(
-          podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
+          podio::collMetadataParamName(inputLocations("CaloHitsCollections")[0], edm4hep::labels::CellIDEncoding), this)
           .value_or("");
   for (auto i = 0u; i < outputLocationsSize(); ++i)
     k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -185,8 +185,7 @@ template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                                                         clue::AssociationMapHost const& clusterMap,
                                                         ClusterColl& clusters,
-                                                        const std::vector<const CaloHitColl*>& EB_calo_coll,
-                                                        const std::vector<const CaloHitColl*>& EE_calo_coll) const {
+                                                        const std::vector<const CaloHitColl*>& calo_coll) const {
   // Precompute cumulative offsets once
   auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
     std::vector<size_t> offsets;
@@ -199,8 +198,7 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
     return offsets;
   };
 
-  const auto ebOffsets = makeOffsets(EB_calo_coll);
-  const auto eeOffsets = makeOffsets(EE_calo_coll);
+  const auto collOffsets = makeOffsets(calo_coll);
 
   auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
     // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
@@ -210,20 +208,14 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
   };
 
   for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
-    if (clusterMap.empty(cl))
+    if (clusterMap.empty(cl)) // check if there are elements associated with index cl
       continue;
     auto cluster = clusters.create();
     unsigned int maxEnergyIndex = 0;
     float maxEnergyValue = 0.f;
     for (auto index : clusterMap[cl]) {
-      if (clue_hits[index].inBarrel()) {
-        auto [collIdx, localIdx] = resolveIndex(ebOffsets, index);
-        cluster.addToHits(EB_calo_coll[collIdx]->at(localIdx));
-      }
-      if (clue_hits[index].inEndcap()) {
-        auto [collIdx, localIdx] = resolveIndex(eeOffsets, index);
-        cluster.addToHits(EE_calo_coll[collIdx]->at(localIdx));
-      }
+        auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
+        cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
       if (clue_hits[index].getEnergy() > maxEnergyValue) {
         maxEnergyValue = clue_hits[index].getEnergy();
@@ -247,76 +239,68 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
   return;
 }
 
-template <>
-void ClueGaudiAlgorithmWrapper<2>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
-                                                     clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-                                                     const std::vector<const CaloHitColl*>& EB_calo_coll,
-                                                     const std::vector<const CaloHitColl*>& EE_calo_coll) const {
-  // Precompute cumulative offsets once
-  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
-    std::vector<size_t> offsets;
-    offsets.reserve(colls.size());
-    size_t acc = 0;
-    for (const auto& c : colls) {
-      offsets.push_back(acc);
-      acc += c->size();
-    }
-    return offsets;
-  };
-
-  const auto ebOffsets = makeOffsets(EB_calo_coll);
-  const auto eeOffsets = makeOffsets(EE_calo_coll);
-
-  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
-    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
-    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
-    size_t collIdx = std::distance(offsets.begin(), it) - 1;
-    return {collIdx, globalIndex - offsets[collIdx]};
-  };
-
-  for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
-    std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
-    for (auto index : clusterMap[cl]) {
-      clustersLayer[clue_hits[index].getLayer()].push_back(index);
-    }
-    for (auto clLay : clustersLayer) {
-      if (clLay.empty())
-        continue;
-      auto cluster = clusters.create();
-      unsigned int maxEnergyIndex = 0;
-      float maxEnergyValue = 0.f;
-      for (auto index : clusterMap[cl]) {
-        if (clue_hits[index].inBarrel()) {
-          auto [collIdx, localIdx] = resolveIndex(ebOffsets, index);
-          cluster.addToHits(EB_calo_coll[collIdx]->at(localIdx));
-        }
-        if (clue_hits[index].inEndcap()) {
-          auto [collIdx, localIdx] = resolveIndex(eeOffsets, index);
-          cluster.addToHits(EE_calo_coll[collIdx]->at(localIdx));
-        }
-
-        if (clue_hits[index].getEnergy() > maxEnergyValue) {
-          maxEnergyValue = clue_hits[index].getEnergy();
-          maxEnergyIndex = index;
-        }
-      }
-      float energy = 0.f;
-      float sumEnergyErrSquared = 0.f;
-      std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
-                    [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
-                      energy += elem.getEnergy();
-                      sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
-                    });
-      cluster.setEnergy(energy);
-      cluster.setEnergyError(sqrt(sumEnergyErrSquared));
-
-      calculatePosition(&cluster);
-
-      cluster.setType(clue_hits[maxEnergyIndex].getType());
-    }
-  }
-  return;
-}
+//template <>
+//void ClueGaudiAlgorithmWrapper<2>::fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
+//                                                     clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
+//                                                     const std::vector<const CaloHitColl*>& calo_coll) const {
+//  // Precompute cumulative offsets once
+//  auto makeOffsets = [](const std::vector<const CaloHitColl*>& colls) {
+//    std::vector<size_t> offsets;
+//    offsets.reserve(colls.size());
+//    size_t acc = 0;
+//    for (const auto& c : colls) {
+//      offsets.push_back(acc);
+//      acc += c->size();
+//    }
+//    return offsets;
+//  };
+//
+//  const auto offsets = makeOffsets(calo_coll);
+//
+//  auto resolveIndex = [](const std::vector<size_t>& offsets, size_t globalIndex) -> std::pair<size_t, size_t> {
+//    // upper_bound finds the first offset > globalIndex, so the correct coll is the one before
+//    auto it = std::upper_bound(offsets.begin(), offsets.end(), globalIndex);
+//    size_t collIdx = std::distance(offsets.begin(), it) - 1;
+//    return {collIdx, globalIndex - offsets[collIdx]};
+//  };
+//
+//  for (auto cl = 0u; cl < clusterMap.size(); ++cl) {
+//    std::vector<std::vector<int>> clustersLayer(m_maxLayerPerSide * 2);
+//    for (auto index : clusterMap[cl]) {
+//      clustersLayer[clue_hits[index].getLayer()].push_back(index);
+//    }
+//    for (auto clLay : clustersLayer) {
+//      if (clLay.empty())
+//        continue;
+//      auto cluster = clusters.create();
+//      unsigned int maxEnergyIndex = 0;
+//      float maxEnergyValue = 0.f;
+//      for (auto index : clusterMap[cl]) {
+//        auto [collIdx, localIdx] = resolveIndex(offsets, index);
+//        cluster.addToHits(calo_coll[collIdx]->at(localIdx));
+//
+//        if (clue_hits[index].getEnergy() > maxEnergyValue) {
+//          maxEnergyValue = clue_hits[index].getEnergy();
+//          maxEnergyIndex = index;
+//        }
+//      }
+//      float energy = 0.f;
+//      float sumEnergyErrSquared = 0.f;
+//      std::for_each(cluster.getHits().begin(), cluster.getHits().end(),
+//                    [&energy, &sumEnergyErrSquared](edm4hep::CalorimeterHit elem) {
+//                      energy += elem.getEnergy();
+//                      sumEnergyErrSquared += pow(elem.getEnergyError() / (1. * elem.getEnergy()), 2);
+//                    });
+//      cluster.setEnergy(energy);
+//      cluster.setEnergyError(sqrt(sumEnergyErrSquared));
+//
+//      calculatePosition(&cluster);
+//
+//      cluster.setType(clue_hits[maxEnergyIndex].getType());
+//    }
+//  }
+//  return;
+//}
 
 template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::calculatePosition(edm4hep::MutableCluster* cluster) const {
@@ -381,75 +365,104 @@ void ClueGaudiAlgorithmWrapper<nDim>::transformClustersInCaloHits(ClusterColl& c
 }
 
 template <uint8_t nDim>
-retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const CaloHitColl*>& EB_calo_coll,
-                                                    const std::vector<const CaloHitColl*>& EE_calo_coll) const {
+retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const CaloHitColl*>& calo_coll) const {
 
-  // Get collection metadata cellID which is valid for both EB and EE
-  const std::string cellIDstr =
-      k4FWCore::getCellIDEncoding(inputLocations("BarrelCaloHitsCollection")[0], this).value_or("");
-  const BitFieldCoder bf(cellIDstr);
+  const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
+  for (auto s : ClusterCollectionsNames)
+    std::cout <<  s << std::endl;
 
   // Output CLUE clusters
   auto finalClusters = ClusterColl();
 
   // Output CLUE calo hits
   clue::CLUECalorimeterHitCollection clue_hit_coll;
-  clue::CLUECalorimeterHitCollection clue_hit_coll_barrel;
-  clue::CLUECalorimeterHitCollection clue_hit_coll_endcap;
 
-  // Fill CLUECaloHits in the barrel
-  for (const auto& coll : EB_calo_coll) {
-    for (const auto& calo_hit : *coll) {
-      // Cut on a specific layer for noise studies
-      // if(bf.get( calo_hit.getCellID(), "layer") == 6){
-      clue_hit_coll_barrel.vect.push_back(clue::CLUECalorimeterHit(
-          calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::barrel, bf.get(calo_hit.getCellID(), "layer")));
-      //}
-    }
-  }
-  info() << "Processing " << clue_hit_coll_barrel.vect.size() << " caloHits in the barrel." << endmsg;
-
-  // Run CLUE in the barrel
-  if (!clue_hit_coll_barrel.vect.empty()) {
-    auto clueClustersBarrel = runAlgo(clue_hit_coll_barrel.vect);
-    info() << "Produced " << clueClustersBarrel.size() << " clusters in the barrel" << endmsg;
-
-    clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_barrel.vect.begin(),
-                              clue_hit_coll_barrel.vect.end());
-
-    fillFinalClusters(clue_hit_coll_barrel.vect, clueClustersBarrel, finalClusters, EB_calo_coll, EE_calo_coll);
-    debug() << "Saved " << finalClusters.size() << " clusters using barrel hits" << endmsg;
-  }
-  uint32_t barrelOffset = finalClusters.size();
-
-  // Fill CLUECaloHits in the endcap
-  for (const auto& coll : EE_calo_coll) {
-    for (const auto& calo_hit : *coll) {
-      if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
-        clue_hit_coll_endcap.vect.push_back(clue::CLUECalorimeterHit(
-            calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap, bf.get(calo_hit.getCellID(), "layer")));
-      } else {
-        clue_hit_coll_endcap.vect.push_back(
-            clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
-                                     bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
+  if (m_singlePass) {
+    for (const auto& coll : calo_coll) {
+      for (const auto& calo_hit : *coll) {
+        clue_hit_coll.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
       }
     }
+    info() << "Processing " << clue_hit_coll.vect.size() << " caloHits." << endmsg;
+
+    if (!clue_hit_coll.vect.empty()) {
+      auto clueClusters = runAlgo(clue_hit_coll.vect);
+      info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
+
+      fillFinalClusters(clue_hit_coll.vect, clueClusters, finalClusters, calo_coll);
+      debug() << "Saved " << finalClusters.size() << " clusters" << endmsg;
+    } else {
+      info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
+    }
+  } else {
+    int offset = 0;
+    for (const auto& coll : calo_coll) {
+      clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
+      for (const auto& calo_hit : *coll) {
+        clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
+      }
+      info() << "Processing " << clue_hit_coll_tmp.vect.size() << " caloHits." << endmsg;
+
+      if (!clue_hit_coll_tmp.vect.empty()) {
+        auto clueClusters = runAlgo(clue_hit_coll_tmp.vect, offset);
+        info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
+
+        fillFinalClusters(clue_hit_coll_tmp.vect, clueClusters, finalClusters, calo_coll);
+        debug() << "Saved " << finalClusters.size() - offset << " clusters" << endmsg;
+
+        clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_tmp.vect.begin(),
+                              clue_hit_coll_tmp.vect.end());
+      } else {
+        info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
+      }
+      offset += clue_hit_coll_tmp.vect.size();
+    }
   }
-  info() << "Processing " << clue_hit_coll_endcap.vect.size() << " caloHits in the endcap." << endmsg;
 
-  // Run CLUE in the endcap
-  if (!clue_hit_coll_endcap.vect.empty()) {
-    auto clueClustersEndcap = runAlgo(clue_hit_coll_endcap.vect, false, barrelOffset);
-    info() << "Produced " << clueClustersEndcap.size() << " clusters in the endcap" << endmsg;
+  // Get collection metadata cellID which is valid for both EB and EE
+  //const std::string cellIDstr =
+  //    k4FWCore::getParameter<std::string>(
+  //        podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
+  //        .value_or("");
+  //const BitFieldCoder bf(cellIDstr);
 
-    clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_endcap.vect.begin(),
-                              clue_hit_coll_endcap.vect.end());
+  //// Fill CLUECaloHits in the barrel
+  //for (const auto& coll : EB_calo_coll) {
+  //  for (const auto& calo_hit : *coll) {
+  //    clue_hit_coll_barrel.vect.push_back(clue::CLUECalorimeterHit(
+  //        calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::barrel, bf.get(calo_hit.getCellID(), "layer")));
+  //  }
+  //}
+  //uint32_t barrelOffset = finalClusters.size();
 
-    fillFinalClusters(clue_hit_coll_endcap.vect, clueClustersEndcap, finalClusters, EB_calo_coll, EE_calo_coll);
-    debug() << "Saved " << finalClusters.size() - barrelOffset << " clusters using endcap hits" << endmsg;
-  }
+  //// Fill CLUECaloHits in the endcap
+  //for (const auto& coll : EE_calo_coll) {
+  //  for (const auto& calo_hit : *coll) {
+  //    if (bf.get(calo_hit.getCellID(), "side") < 0 || bf.get(calo_hit.getCellID(), "side") > 1) {
+  //      clue_hit_coll_endcap.vect.push_back(clue::CLUECalorimeterHit(
+  //          calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap, bf.get(calo_hit.getCellID(), "layer")));
+  //    } else {
+  //      clue_hit_coll_endcap.vect.push_back(
+  //          clue::CLUECalorimeterHit(calo_hit.clone(), clue::CLUECalorimeterHit::DetectorRegion::endcap,
+  //                                   bf.get(calo_hit.getCellID(), "layer") + m_maxLayerPerSide));
+  //    }
+  //  }
+  //}
+  //info() << "Processing " << clue_hit_coll_endcap.vect.size() << " caloHits in the endcap." << endmsg;
 
-  info() << "Saved " << finalClusters.size() << " CLUE clusters in total." << endmsg;
+  //// Run CLUE in the endcap
+  //if (!clue_hit_coll_endcap.vect.empty()) {
+  //  auto clueClustersEndcap = runAlgo(clue_hit_coll_endcap.vect, false, barrelOffset);
+  //  info() << "Produced " << clueClustersEndcap.size() << " clusters in the endcap" << endmsg;
+
+  //  clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_endcap.vect.begin(),
+  //                            clue_hit_coll_endcap.vect.end());
+
+  //  fillFinalClusters(clue_hit_coll_endcap.vect, clueClustersEndcap, finalClusters, EB_calo_coll, EE_calo_coll);
+  //  debug() << "Saved " << finalClusters.size() - barrelOffset << " clusters using endcap hits" << endmsg;
+  //}
+
+  //info() << "Saved " << finalClusters.size() << " CLUE clusters in total." << endmsg;
 
   // Save CLUE calo hits
   auto pCHV = std::make_unique<clue::CLUECalorimeterHitCollection>(clue_hit_coll);
@@ -463,6 +476,15 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
   auto finalCaloHits = CaloHitColl();
   transformClustersInCaloHits(finalClusters, finalCaloHits);
   debug() << "Saved " << finalCaloHits.size() << " clusters as calo hits" << endmsg;
+
+  // Add CellIDEncodingString to CLUE clusters and CLUE calo hits
+  // Get collection metadata cellID which is valid for both EB and EE
+  const std::string cellIDstr =
+      k4FWCore::getParameter<std::string>(
+          podio::collMetadataParamName("ECalBarrelCollection", edm4hep::labels::CellIDEncoding), this)
+          .value_or("");
+  for (auto i = 0u; i < outputLocationsSize(); ++i)
+    k4FWCore::putParameter(outputLocations(i)[0] + "__CellIDEncoding", cellIDstr, this);
 
   // Cleaning
   clue_hit_coll.vect.clear();

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -61,9 +61,8 @@ struct ClueGaudiAlgorithmWrapper final
   void printTimingReport(std::vector<float>& vals, int repeats, const std::string label);
 
   clue::PointsHost<nDim> fillCLUEPoints(const std::vector<clue::CLUECalorimeterHit>& clue_hits, float* floatBuffer,
-                                        int* intBuffer, const bool isBarrel) const;
-  clue::AssociationMapHost runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const bool isBarrel = true,
-                                   const uint32_t offset = 0) const;
+                                        int* intBuffer, const bool cartesian) const;
+  clue::AssociationMapHost runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const uint32_t offset = 0, const bool cartesian = true) const;
 
   void fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -38,20 +38,22 @@ using retType = std::tuple<ClusterColl, CaloHitColl>;
 
 template <uint8_t nDim>
 struct ClueGaudiAlgorithmWrapper final
-    : k4FWCore::MultiTransformer<retType(const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll)> {
+    : k4FWCore::MultiTransformer<retType(const std::vector<const CaloHitColl*>& EB_calo_coll,
+                                         const std::vector<const CaloHitColl*>& EE_calo_coll)> {
 
   ClueGaudiAlgorithmWrapper(const std::string& name, ISvcLocator* svcLoc)
       : MultiTransformer(name, svcLoc,
                          {
-                             KeyValue("BarrelCaloHitsCollection", "ECALBarrel"),
-                             KeyValue("EndcapCaloHitsCollection", "ECALEndcap"),
+                             KeyValues("BarrelCaloHitsCollection", {"ECALBarrel"}),
+                             KeyValues("EndcapCaloHitsCollection", {"ECALEndcap"}),
                          },
                          {
                              KeyValue("OutputClusters", "CLUEClusters"),
                              KeyValue("OutputClustersAsHits", "CLUEClustersAsHits"),
                          }) {}
 
-  retType operator()(const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll) const override;
+  retType operator()(const std::vector<const CaloHitColl*>& EB_calo_coll,
+                     const std::vector<const CaloHitColl*>& EE_calo_coll) const override;
 
   StatusCode initialize() override;
   StatusCode finalize() override;
@@ -68,7 +70,8 @@ struct ClueGaudiAlgorithmWrapper final
 
   void fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-                         const CaloHitColl& EB_calo_coll, const CaloHitColl& EE_calo_coll) const;
+                         const std::vector<const CaloHitColl*>& EB_calo_coll,
+                         const std::vector<const CaloHitColl*>& EE_calo_coll) const;
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
 

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -101,6 +101,8 @@ private:
 
   Gaudi::Property<std::string> m_CLUECaloHitCollName{this, "CLUEHitCollName", "CLUECalorimeterHitCollection",
                                                      "Name of the collection of CLUE calorimeter hits"};
+  Gaudi::Property<bool> m_saveClustersAsHits{this, "SaveClustersAsHits", false,
+                                             "Whether to save clusters as hits in addition to regular clusters"};
 
   Gaudi::Property<std::string> m_strategyName{this, "strategy", "MergeCollections",
                                               "strategy to treat different collections"};

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -68,21 +68,14 @@ struct ClueGaudiAlgorithmWrapper final
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
                          const std::vector<const CaloHitColl*>& calo_coll) const;
   void fillFinalClustersPerLayer(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
-                         clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-                         const std::vector<const CaloHitColl*>& calo_coll) const;
+                                 clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
+                                 const std::vector<const CaloHitColl*>& calo_coll) const;
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
 
-  enum class Coordinate {
-    Cartesian,
-    Polar
-  };
+  enum class Coordinate { Cartesian, Polar };
 
-  enum class Strategy {
-    PerCollection,
-    MergeCollections,
-    PerDetectorRegion
-  };
+  enum class Strategy { PerCollection, MergeCollections, PerDetectorRegion };
 
 private:
   // Total amount of EE+ and EE- layers (80)
@@ -110,13 +103,12 @@ private:
                                                      "Name of the collection of CLUE calorimeter hits"};
 
   Gaudi::Property<std::string> m_strategyName{this, "strategy", "MergeCollections",
-                                      "strategy to treat different collections"};
+                                              "strategy to treat different collections"};
   Strategy m_strategy;
 
   Gaudi::Property<std::string> m_coordinateName{this, "coordinate", "Cartesian",
-                                      "coordinates to use to cluster points"};
+                                                "coordinates to use to cluster points"};
   Coordinate m_coordinate;
-
 };
 
 #endif

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -38,22 +38,19 @@ using retType = std::tuple<ClusterColl, CaloHitColl>;
 
 template <uint8_t nDim>
 struct ClueGaudiAlgorithmWrapper final
-    : k4FWCore::MultiTransformer<retType(const std::vector<const CaloHitColl*>& EB_calo_coll,
-                                         const std::vector<const CaloHitColl*>& EE_calo_coll)> {
+    : k4FWCore::MultiTransformer<retType(const std::vector<const CaloHitColl*>& calo_coll)> {
 
   ClueGaudiAlgorithmWrapper(const std::string& name, ISvcLocator* svcLoc)
       : MultiTransformer(name, svcLoc,
                          {
-                             KeyValues("BarrelCaloHitsCollection", {"ECALBarrel"}),
-                             KeyValues("EndcapCaloHitsCollection", {"ECALEndcap"}),
+                             KeyValues("CaloHitsCollections", {"ECALBarrel", "ECALEndcap"}),
                          },
                          {
                              KeyValue("OutputClusters", "CLUEClusters"),
                              KeyValue("OutputClustersAsHits", "CLUEClustersAsHits"),
                          }) {}
 
-  retType operator()(const std::vector<const CaloHitColl*>& EB_calo_coll,
-                     const std::vector<const CaloHitColl*>& EE_calo_coll) const override;
+  retType operator()(const std::vector<const CaloHitColl*>& calo_coll) const override;
 
   StatusCode initialize() override;
   StatusCode finalize() override;
@@ -70,8 +67,7 @@ struct ClueGaudiAlgorithmWrapper final
 
   void fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
-                         const std::vector<const CaloHitColl*>& EB_calo_coll,
-                         const std::vector<const CaloHitColl*>& EE_calo_coll) const;
+                         const std::vector<const CaloHitColl*>& calo_coll) const;
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
 
@@ -99,6 +95,9 @@ private:
 
   Gaudi::Property<std::string> m_CLUECaloHitCollName{this, "CLUEHitCollName", "CLUECalorimeterHitCollection",
                                                      "Name of the collection of CLUE calorimeter hits"};
+
+  Gaudi::Property<int> m_singlePass{this, "strategy", 1,
+                                      "strategy to treat different collections"};
 };
 
 #endif

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -70,6 +70,12 @@ struct ClueGaudiAlgorithmWrapper final
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
 
+  enum class Strategy {
+    PerCollection,
+    MergeCollections,
+    PerDetectorRegion
+  };
+
 private:
   // Total amount of EE+ and EE- layers (80)
   int m_maxLayerPerSide = 40;
@@ -95,8 +101,10 @@ private:
   Gaudi::Property<std::string> m_CLUECaloHitCollName{this, "CLUEHitCollName", "CLUECalorimeterHitCollection",
                                                      "Name of the collection of CLUE calorimeter hits"};
 
-  Gaudi::Property<int> m_singlePass{this, "strategy", 1,
+  Gaudi::Property<std::string> m_strategyName{this, "strategy", "MergeCollections",
                                       "strategy to treat different collections"};
+  Strategy m_strategy;
+
 };
 
 #endif

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -90,7 +90,7 @@ private:
   Gaudi::Property<float> m_rhoc{this, "MinLocalDensity", 1.0f,
                                 "Minimum energy density of a point to not be considered an outlier"};
 
-  Gaudi::Property<float> m_dm{this, "FollowerDistance", 1.0f,
+  Gaudi::Property<float> m_dm{this, "FollowerDistance", -1.0f,
                               "Critical distance for follower search and cluster expansion"};
 
   Gaudi::Property<float> m_seed_dc{this, "SeedCriticalDistance", -1.0f,

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -61,8 +61,8 @@ struct ClueGaudiAlgorithmWrapper final
   void printTimingReport(std::vector<float>& vals, int repeats, const std::string label);
 
   clue::PointsHost<nDim> fillCLUEPoints(const std::vector<clue::CLUECalorimeterHit>& clue_hits, float* floatBuffer,
-                                        int* intBuffer, const bool cartesian) const;
-  clue::AssociationMapHost runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const uint32_t offset = 0, const bool cartesian = true) const;
+                                        int* intBuffer) const;
+  clue::AssociationMapHost runAlgo(std::vector<clue::CLUECalorimeterHit>& clue_hits, const uint32_t offset = 0) const;
 
   void fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
@@ -72,6 +72,11 @@ struct ClueGaudiAlgorithmWrapper final
                          const std::vector<const CaloHitColl*>& calo_coll) const;
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
+
+  enum class Coordinate {
+    Cartesian,
+    Polar
+  };
 
   enum class Strategy {
     PerCollection,
@@ -107,6 +112,10 @@ private:
   Gaudi::Property<std::string> m_strategyName{this, "strategy", "MergeCollections",
                                       "strategy to treat different collections"};
   Strategy m_strategy;
+
+  Gaudi::Property<std::string> m_coordinateName{this, "coordinate", "Cartesian",
+                                      "coordinates to use to cluster points"};
+  Coordinate m_coordinate;
 
 };
 

--- a/src/ClueGaudiAlgorithmWrapper.h
+++ b/src/ClueGaudiAlgorithmWrapper.h
@@ -67,6 +67,9 @@ struct ClueGaudiAlgorithmWrapper final
   void fillFinalClusters(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
                          clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
                          const std::vector<const CaloHitColl*>& calo_coll) const;
+  void fillFinalClustersPerLayer(std::vector<clue::CLUECalorimeterHit> const& clue_hits,
+                         clue::AssociationMapHost const& clusterMap, ClusterColl& clusters,
+                         const std::vector<const CaloHitColl*>& calo_coll) const;
   void calculatePosition(edm4hep::MutableCluster* cluster) const;
   void transformClustersInCaloHits(ClusterColl& clusters, CaloHitColl& caloHits) const;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Enable the possibility to pass multiple collections to k4Clue, without the Barrel / Endcap separation
- Add the possibility to choose how to cluster these collections: all together, one at a time, divided per detector region  
- Implemented polar coordinates and the possibility to choose between those and Cartesian coordinates
- Implemented 4D clustering with weighted Euclidean metric
- refactor the `CLUECalorimeterHit` data format internally
- Add the option to not save the `CLUEClustersAsHIts` collection
ENDRELEASENOTES

The way `CLUECalorimeterHit` is used does not copy the custom internal states (e.g. `m_theta`, `m_phi`). Hence, the `get...()` methods returned garbage values when retrieving the polar coordinate. To fix this, the internal states have been removed, and the coordinates are computed on-the-fly.
The `CLUEClustersAsHIts` collection will be removed once the external clustering is integrated into Pandora

This is a follow-up of the discussion in #77 to try to avoid code duplication

FYI @SanghyunKo