### PR TITLE
Fix output in ClueGaudiAlgorithmWrapper.cc and other fixes

### DIFF
--- a/include/CLUECalorimeterHit.h
+++ b/include/CLUECalorimeterHit.h
@@ -80,12 +80,12 @@ public:
   void setClusterIndex(int32_t clIdx) { m_clusterIndex = clIdx; }
 
 private:
-  float m_rho;
-  float m_delta;
-  uint8_t m_detectorRegion;
-  uint8_t m_status;
-  uint32_t m_layer;
-  int32_t m_clusterIndex;
+  float m_rho{0.f};
+  float m_delta{0.f};
+  uint8_t m_detectorRegion{barrel};
+  uint8_t m_status{outlier};
+  uint32_t m_layer{0};
+  int32_t m_clusterIndex{-1};
 };
 
 class CLUECalorimeterHitCollection : public DataObject {

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -122,12 +122,14 @@ StatusCode ClueGaudiAlgorithmWrapper<nDim>::initialize() {
 
 template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::exclude_stats_outliers(std::vector<float>& v) {
-  if (v.size() == 1)
+  if (v.size() < 2)
     return;
   float mean = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
   float sum_sq_diff = std::accumulate(v.begin(), v.end(), 0.0,
                                       [mean](float acc, float val) { return acc + (val - mean) * (val - mean); });
   float stddev = std::sqrt(sum_sq_diff / (v.size() - 1));
+  if (stddev == 0.f)
+    return;
   std::cout << "Sigma cut outliers: " << stddev << std::endl;
   float z_score_threshold = 3.0;
   v.erase(std::remove_if(v.begin(), v.end(),
@@ -140,6 +142,9 @@ void ClueGaudiAlgorithmWrapper<nDim>::exclude_stats_outliers(std::vector<float>&
 
 template <uint8_t nDim>
 std::pair<float, float> ClueGaudiAlgorithmWrapper<nDim>::stats(const std::vector<float>& v) {
+  if (v.empty())
+    return {0.f, 0.f};
+
   float m = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
   float sum =
       std::accumulate(v.begin(), v.end(), 0.0, [m](float acc, float val) { return acc + (val - m) * (val - m); });
@@ -237,16 +242,24 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
   debug() << "Finished running CLUE algorithm" << endmsg;
 
   // Including CLUE info in cluePoints
+  const auto clusterIndexes = cluePoints.clusterIndexes();
+  const auto isSeed = cluePoints.isSeed();
+  const auto& pointsView = cluePoints.view();
   for (int32_t i = 0; i < cluePoints.size(); i++) {
     // offset is 0 for the barrel and is the number of clusters in the barrel for the endcap
-    clue_hits[i].setClusterIndex(cluePoints.clusterIndexes()[i] + offset);
+    clue_hits[i].setRho(pointsView.rho[i]);
+    clue_hits[i].setDelta(pointsView.delta[i]);
+    clue_hits[i].setClusterIndex(clusterIndexes[i] + offset);
     verbose() << "CLUE Point #" << i << " : (x,y,z) = (" << clue_hits[i].getPosition().x << ","
               << clue_hits[i].getPosition().y << "," << clue_hits[i].getPosition().z << ")";
-    if (cluePoints.clusterIndexes()[i] == -1) {
+    if (clusterIndexes[i] == -1) {
       verbose() << " is outlier" << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::outlier);
+    } else if (isSeed[i] != 0) {
+      verbose() << " is seed of cluster #" << clusterIndexes[i] << endmsg;
+      clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::seed);
     } else {
-      verbose() << " is follower of cluster #" << cluePoints.clusterIndexes()[i] << endmsg;
+      verbose() << " is follower of cluster #" << clusterIndexes[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::follower);
     }
   } // for cluePoints
@@ -267,21 +280,24 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClusters(std::vector<clue::CLUECa
       continue;
 
     auto cluster = clusters.create();
-    unsigned int maxEnergyIndex = 0;
+    size_t maxEnergyIndex = 0;
     float maxEnergyValue = 0.f;
     float energy = 0.f;
     float sumEnergyErrSquared = 0.f;
+    bool hasMaxEnergy = false;
     for (auto index : clusterMap[cl]) {
       auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
       cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
       float hitEne = clue_hits[index].getEnergy();
-      if (hitEne > maxEnergyValue) {
+      if (!hasMaxEnergy || hitEne > maxEnergyValue) {
         maxEnergyValue = hitEne;
         maxEnergyIndex = index;
+        hasMaxEnergy = true;
       }
       energy += hitEne;
-      sumEnergyErrSquared += pow(clue_hits[index].getEnergyError() / (1.f * hitEne), 2);
+      const float hitEnergyError = clue_hits[index].getEnergyError();
+      sumEnergyErrSquared += hitEnergyError * hitEnergyError;
     }
     cluster.setEnergy(energy);
     cluster.setEnergyError(std::sqrt(sumEnergyErrSquared));
@@ -312,21 +328,24 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
         if (clLay.empty())
           continue;
         auto cluster = clusters.create();
-        unsigned int maxEnergyIndex = 0;
+        size_t maxEnergyIndex = 0;
         float maxEnergyValue = 0.f;
         float energy = 0.f;
         float sumEnergyErrSquared = 0.f;
+        bool hasMaxEnergy = false;
         for (auto index : clLay) {
           auto [collIdx, localIdx] = resolveIndex(collOffsets, index);
           cluster.addToHits(calo_coll[collIdx]->at(localIdx));
 
           float hitEne = clue_hits[index].getEnergy();
-          if (hitEne > maxEnergyValue) {
+          if (!hasMaxEnergy || hitEne > maxEnergyValue) {
             maxEnergyValue = hitEne;
             maxEnergyIndex = index;
+            hasMaxEnergy = true;
           }
           energy += hitEne;
-          sumEnergyErrSquared += pow(clue_hits[index].getEnergyError() / (1.f * hitEne), 2);
+          const float hitEnergyError = clue_hits[index].getEnergyError();
+          sumEnergyErrSquared += hitEnergyError * hitEnergyError;
         }
         cluster.setEnergy(energy);
         cluster.setEnergyError(sqrt(sumEnergyErrSquared));
@@ -346,8 +365,10 @@ void ClueGaudiAlgorithmWrapper<nDim>::fillFinalClustersPerLayer(
 template <uint8_t nDim>
 void ClueGaudiAlgorithmWrapper<nDim>::calculatePosition(edm4hep::MutableCluster* cluster) const {
   float total_weight = cluster->getEnergy();
-  if (total_weight <= 0)
+  if (total_weight <= 0) {
     warning() << "Zero energy in the cluster" << endmsg;
+    return;
+  }
 
   float total_weight_log = 0.f;
   float x_log = 0.f;
@@ -358,12 +379,18 @@ void ClueGaudiAlgorithmWrapper<nDim>::calculatePosition(edm4hep::MutableCluster*
 
   for (size_t i = 0; i < cluster->hits_size(); i++) {
     float rhEnergy = cluster->getHits(i).getEnergy();
+    if (rhEnergy <= 0.f)
+      continue;
+
     float Wi = std::max(thresholdW0_ - std::log(rhEnergy / total_weight), 0.f);
+    if (Wi <= 0.f)
+      continue;
+
     x_log += cluster->getHits(i).getPosition().x * Wi;
     y_log += cluster->getHits(i).getPosition().y * Wi;
     z_log += cluster->getHits(i).getPosition().z * Wi;
     total_weight_log += Wi;
-    error = +1.f / Wi;
+    error += 1.f / Wi;
   }
 
   if (total_weight_log != 0.) {
@@ -433,11 +460,12 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
       info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
     }
   } else if (m_strategy == Strategy::PerCollection) {
-    int offset = 0;
+    uint32_t offset = 0;
     int collIndex = 0;
     const std::vector<std::string> ClusterCollectionsNames = inputLocations("CaloHitsCollections");
     for (const auto& coll : calo_coll) {
       clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
+      const std::vector<const CaloHitColl*> currentCaloColl{coll};
       for (const auto& calo_hit : *coll) {
         clue_hit_coll_tmp.vect.push_back(clue::CLUECalorimeterHit(calo_hit.clone()));
       }
@@ -449,14 +477,14 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
         auto clueClusters = runAlgo(clue_hit_coll_tmp.vect, offset);
         info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
 
-        fillFinalClusters(clue_hit_coll_tmp.vect, clueClusters, finalClusters, calo_coll);
+        fillFinalClusters(clue_hit_coll_tmp.vect, clueClusters, finalClusters, currentCaloColl);
 
         clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_tmp.vect.begin(),
                                   clue_hit_coll_tmp.vect.end());
+        offset += static_cast<uint32_t>(clueClusters.size());
       } else {
         info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
       }
-      offset += clue_hit_coll_tmp.vect.size();
     }
 
     debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
@@ -468,10 +496,11 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
     const BitFieldCoder bf(cellIDstr);
 
     // Fill CLUECaloHits per region
-    int offset = 0;
+    uint32_t offset = 0;
     int collIndex = 0;
     for (const auto& coll : calo_coll) {
       clue::CLUECalorimeterHitCollection clue_hit_coll_tmp;
+      const std::vector<const CaloHitColl*> currentCaloColl{coll};
       std::string const& collName = ClusterCollectionsNames[collIndex];
       collIndex++;
       if (collName.find("Barrel") != std::string::npos) {
@@ -501,15 +530,15 @@ retType ClueGaudiAlgorithmWrapper<nDim>::operator()(const std::vector<const Calo
         auto clueClusters = runAlgo(clue_hit_coll_tmp.vect, offset);
         info() << "Produced " << clueClusters.size() << " clusters" << endmsg;
 
-        fillFinalClustersPerLayer(clue_hit_coll_tmp.vect, clueClusters, finalClusters, calo_coll);
+        fillFinalClustersPerLayer(clue_hit_coll_tmp.vect, clueClusters, finalClusters, currentCaloColl);
 
         clue_hit_coll.vect.insert(clue_hit_coll.vect.end(), clue_hit_coll_tmp.vect.begin(),
                                   clue_hit_coll_tmp.vect.end());
+        offset += static_cast<uint32_t>(clueClusters.size());
       } else {
         info() << "No calorimeter hits to process, skipping CLUE algorithm" << endmsg;
       }
 
-      offset += clue_hit_coll_tmp.vect.size();
     } // for each collection
     debug() << "Saved " << finalClusters.size() << " clusters in total" << endmsg;
   } // if-else on strategy

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -244,17 +244,19 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
   // Including CLUE info in cluePoints
   const auto clusterIndexes = cluePoints.clusterIndexes();
   const auto& pointsView = cluePoints.view();
+  const auto rho = pointsView.rho();
   for (int32_t i = 0; i < cluePoints.size(); i++) {
     // offset is 0 for the barrel and is the number of clusters in the barrel for the endcap
-    clue_hits[i].setRho(pointsView.rho[i]);
-    clue_hits[i].setDelta(pointsView.delta[i]);
+    clue_hits[i].setRho(rho[i]);
+    // CLUEstering no longer retains the per-point delta after clustering.
+    // CLUECalorimeterHit keeps its zero-initialized diagnostic value.
     clue_hits[i].setClusterIndex(clusterIndexes[i] + offset);
     verbose() << "CLUE Point #" << i << " : (x,y,z) = (" << clue_hits[i].getPosition().x << ","
               << clue_hits[i].getPosition().y << "," << clue_hits[i].getPosition().z << ")";
     if (clusterIndexes[i] == -1) {
       verbose() << " is outlier" << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::outlier);
-    } else if (cluePoints.isSeed()[i] != 0) {
+    } else if (pointsView.is_seed()[i] != 0) {
       verbose() << " is seed of cluster #" << clusterIndexes[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::seed);
     } else {

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -25,8 +25,6 @@
 
 #include <k4FWCore/MetadataUtils.h>
 
-#include <algorithm>
-
 using namespace dd4hep;
 using namespace DDSegmentation;
 
@@ -245,7 +243,6 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 
   // Including CLUE info in cluePoints
   const auto clusterIndexes = cluePoints.clusterIndexes();
-  const auto seeds = m_clueAlgo->getSeeds();
   for (int32_t i = 0; i < cluePoints.size(); i++) {
     // offset is 0 for the barrel and is the number of clusters in the barrel for the endcap
     clue_hits[i].setClusterIndex(clusterIndexes[i] + offset);
@@ -254,9 +251,6 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
     if (clusterIndexes[i] == -1) {
       verbose() << " is outlier" << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::outlier);
-    } else if (std::ranges::find(seeds, i) != seeds.end()) {
-      verbose() << " is seed of cluster #" << clusterIndexes[i] << endmsg;
-      clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::seed);
     } else {
       verbose() << " is follower of cluster #" << clusterIndexes[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::follower);

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -243,7 +243,6 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 
   // Including CLUE info in cluePoints
   const auto clusterIndexes = cluePoints.clusterIndexes();
-  const auto isSeed = cluePoints.isSeed();
   const auto& pointsView = cluePoints.view();
   for (int32_t i = 0; i < cluePoints.size(); i++) {
     // offset is 0 for the barrel and is the number of clusters in the barrel for the endcap
@@ -255,7 +254,7 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
     if (clusterIndexes[i] == -1) {
       verbose() << " is outlier" << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::outlier);
-    } else if (isSeed[i] != 0) {
+    } else if (cluePoints.isSeed()[i] != 0) {
       verbose() << " is seed of cluster #" << clusterIndexes[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::seed);
     } else {

--- a/src/ClueGaudiAlgorithmWrapper.cpp
+++ b/src/ClueGaudiAlgorithmWrapper.cpp
@@ -25,6 +25,8 @@
 
 #include <k4FWCore/MetadataUtils.h>
 
+#include <algorithm>
+
 using namespace dd4hep;
 using namespace DDSegmentation;
 
@@ -243,20 +245,16 @@ clue::AssociationMapHost ClueGaudiAlgorithmWrapper<nDim>::runAlgo(std::vector<cl
 
   // Including CLUE info in cluePoints
   const auto clusterIndexes = cluePoints.clusterIndexes();
-  const auto& pointsView = cluePoints.view();
-  const auto rho = pointsView.rho();
+  const auto seeds = m_clueAlgo->getSeeds();
   for (int32_t i = 0; i < cluePoints.size(); i++) {
     // offset is 0 for the barrel and is the number of clusters in the barrel for the endcap
-    clue_hits[i].setRho(rho[i]);
-    // CLUEstering no longer retains the per-point delta after clustering.
-    // CLUECalorimeterHit keeps its zero-initialized diagnostic value.
     clue_hits[i].setClusterIndex(clusterIndexes[i] + offset);
     verbose() << "CLUE Point #" << i << " : (x,y,z) = (" << clue_hits[i].getPosition().x << ","
               << clue_hits[i].getPosition().y << "," << clue_hits[i].getPosition().z << ")";
     if (clusterIndexes[i] == -1) {
       verbose() << " is outlier" << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::outlier);
-    } else if (pointsView.is_seed()[i] != 0) {
+    } else if (std::ranges::find(seeds, i) != seeds.end()) {
       verbose() << " is seed of cluster #" << clusterIndexes[i] << endmsg;
       clue_hits[i].setStatus(clue::CLUECalorimeterHit::Status::seed);
     } else {


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix passing the right collection to `fillFinalClusters`. The problem is that `fillFinalClusters` uses `resolveIndex(collOffsets, index)` to map from a global index back to a collection and local index. But when processing per-collection, the indices in `clue_hit_coll_tmp` are local to that single collection, not global across all collections (for example, Collection 0 has 100 hits and then Collection 1 has 50 hits, then asking for index 30 for collection 1 will gives us index 30 of collection 0 because resolveIndex will think we are in collection 0). The fix is to create a vector containing only the current collection being processed.
- Make `hasMaxEnergy` be always a valid index (think of the counter example when every hit has energy 0 to see why the previous code sets it to index 0, which may not be a valid index)
- Avoid divisions and logarithms of zero
- Initialize class members

ENDRELEASENOTES

@AuroraPerego